### PR TITLE
Add controller cleanup to folio lookup screen

### DIFF
--- a/lib/src/presentation/public/folio_lookup_screen.dart
+++ b/lib/src/presentation/public/folio_lookup_screen.dart
@@ -15,6 +15,13 @@ class _FolioLookupScreenState extends ConsumerState<FolioLookupScreen> {
   String? _result;
   String? _error;
 
+  @override
+  void dispose() {
+    //1.- Liberamos el controlador del campo de texto antes de destruir el estado.
+    _folioController.dispose();
+    super.dispose();
+  }
+
   Future<void> _lookup() async {
     //1.- Limpiamos mensajes previos antes de realizar una nueva consulta.
     setState(() {


### PR DESCRIPTION
## Summary
- override the folio lookup screen state dispose method to release the text controller

## Testing
- `flutter test` *(fails: flutter command not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68e4b90caaa883298a64e2c67619b250