### PR TITLE
docs: add module documentation

### DIFF
--- a/docs/app/README.md
+++ b/docs/app/README.md
@@ -1,0 +1,34 @@
+# App Module Overview
+
+## Purpose
+The app layer wires together dependencies, bootstraps shared services, and exposes the top-level widgets that drive navigation and session state for the Citizen Reports experience.
+
+## Key Entry Points
+- [`lib/main.dart`](../../lib/main.dart): Initializes Flutter bindings, builds Riverpod overrides, and launches the `CitizenReportsApp` widget tree.
+- [`lib/src/app/bootstrap.dart`](../../lib/src/app/bootstrap.dart): Creates the in-memory cache, API client, and repository overrides consumed across the app.
+- [`lib/src/app/providers.dart`](../../lib/src/app/providers.dart): Declares the global providers that expose infrastructure and domain use cases.
+- [`lib/src/app/state/session_controller.dart`](../../lib/src/app/state/session_controller.dart): Manages authentication state transitions through a `StateNotifier`.
+- [`lib/src/app/citizen_reports_app.dart`](../../lib/src/app/citizen_reports_app.dart): Selects the proper navigation shell (public, admin, or loading/error screens) based on the current `SessionState`.
+
+## Major Flows
+### Application Bootstrap
+1. `main.dart` ensures bindings are initialized, builds the overrides via `buildAppOverrides`, and wraps the root widget in `ProviderScope`.
+2. `buildAppOverrides` assembles the infrastructure stack (cache, API client, repositories) that satisfy the provider contracts.
+3. `CitizenReportsApp` consumes providers to render either the admin or public navigation graphs.
+
+### Session Management
+1. `sessionControllerProvider` constructs `SessionController` with the `AuthenticateUser` use case.
+2. `SessionController.signIn` transitions through initializing, authenticated, and error states while persisting the returned token.
+3. `SessionController.signOut` resets the state so navigation routes fall back to the public experience.
+
+### Navigation Shell Selection
+1. `CitizenReportsApp` listens to `SessionState` updates to switch between `AdminShell`, `_FullScreenLoader`, `_SessionError`, and `PublicShell`.
+2. `PublicShell` hosts a nested navigator for public routes, while admin flows remain scoped to `AdminShell`.
+
+## Super-Comment Map
+Use the numbered `//1.-`, `//2.-`, … comments in code to trace documented steps:
+- `main.dart`: startup lifecycle (`//1.-` through `//3.-`).
+- `lib/src/app/bootstrap.dart`: dependency assembly (`//1.-`–`//3.-`).
+- `lib/src/app/providers.dart`: provider contracts and use case wiring (`//1.-`).
+- `lib/src/app/state/session_controller.dart`: session transitions (`//1.-`–`//4.-`).
+- `lib/src/app/citizen_reports_app.dart`: navigation switching and UI feedback (`//1.-`).

--- a/docs/data/README.md
+++ b/docs/data/README.md
@@ -1,0 +1,38 @@
+# Data Module Overview
+
+## Purpose
+The data layer implements the repository contracts declared in the domain module. It provides concrete adapters for local caching, simulated REST interactions, and model mapping so higher layers can consume strongly typed entities without knowing about storage details.
+
+## Key Entry Points
+- [`cache/local_cache.dart`](../../lib/src/data/cache/local_cache.dart): In-memory persistence for tokens and report history.
+- [`datasources/api_client.dart`](../../lib/src/data/datasources/api_client.dart): Simulated Dio-based client that fakes backend responses.
+- [`models/mappers.dart`](../../lib/src/data/models/mappers.dart): Conversion helpers between raw maps and domain entities.
+- [`repositories/auth_repository_impl.dart`](../../lib/src/data/repositories/auth_repository_impl.dart): Concrete auth repository handling token persistence and restoration.
+- [`repositories/catalog_repository_impl.dart`](../../lib/src/data/repositories/catalog_repository_impl.dart): Supplies incident types from cache or network.
+- [`repositories/reports_repository_impl.dart`](../../lib/src/data/repositories/reports_repository_impl.dart): Persists report submissions and fetches folio status with offline support.
+
+## Major Flows
+### Authentication Persistence
+1. `AuthRepositoryImpl.authenticate` calls `ApiClient.authenticate`, serializes the token, and stores it under `_tokenKey` within `LocalCache`.
+2. `AuthRepositoryImpl.restoreSession` rehydrates cached tokens, validating expiration before returning them to the domain layer.
+
+### Incident Catalog Retrieval
+1. `CatalogRepositoryImpl.getIncidentTypes` first reads cached entries through `LocalCache.read`.
+2. If cache misses, the repository calls `ApiClient.fetchIncidentTypes`, maps results, and writes them back for offline use.
+
+### Report Submission
+1. `ReportsRepositoryImpl.submitReport` serializes a `ReportRequest`, delegates to `ApiClient.submitReport`, and appends the result to cached history.
+2. The repository returns the mapped `Report` so controllers can surface confirmation details.
+
+### Folio Lookup with Offline Fallback
+1. `ReportsRepositoryImpl.lookupFolio` retrieves cached history to provide immediate feedback while `ApiClient.lookupFolio` executes.
+2. On remote success, the cache updates with the newest status; on failure, the cached snapshot is returned as an offline fallback.
+
+## Super-Comment Map
+Numbered comments explain each repository and datasource step:
+- `cache/local_cache.dart`: storage operations (`//1.-`).
+- `datasources/api_client.dart`: simulated network calls and mappings (`//1.-`, `//2.-`).
+- `repositories/auth_repository_impl.dart`: authentication flow (`//1.-`–`//3.-`).
+- `repositories/catalog_repository_impl.dart`: cache-first catalog retrieval (`//1.-`–`//3.-`).
+- `repositories/reports_repository_impl.dart`: submission, lookup, and caching strategy (`//1.-`–`//4.-`).
+- `models/mappers.dart`: entity serialization/deserialization steps (`//1.-`, `//2.-`).

--- a/docs/domain/README.md
+++ b/docs/domain/README.md
@@ -1,0 +1,35 @@
+# Domain Module Overview
+
+## Purpose
+The domain layer defines the platform-agnostic business rules for Citizen Reports. It expresses core entities, value objects, repositories, and use cases that orchestrate reporting, catalog discovery, authentication, and folio tracking.
+
+## Key Entry Points
+- [`entities/`](../../lib/src/domain/entities): Immutable models representing incidents, reports, folio status, and credentials consumed across the app.
+- [`value_objects/`](../../lib/src/domain/value_objects): Types such as `AuthToken` that embed invariants like expiration checks.
+- [`repositories/`](../../lib/src/domain/repositories): Abstract contracts consumed by use cases to request data or persist state.
+- [`usecases/`](../../lib/src/domain/usecases): Application-specific actions that coordinate validation and repository delegation.
+- [`exceptions/validation_exception.dart`](../../lib/src/domain/exceptions/validation_exception.dart): Domain-level error surfaced when business rules are violated.
+
+## Major Flows
+### User Authentication
+1. `AuthenticateUser` delegates to `AuthRepository.authenticate` to validate credentials and receive a token.
+2. The resulting `AuthToken` enforces expiration logic before the app exposes authenticated routes.
+
+### Incident Reporting
+1. `SubmitReport` validates request fields (email, phone length, description) before contacting the repository.
+2. Upon success, the use case returns a strongly typed `Report` entity for presentation and caching layers.
+
+### Catalog Retrieval
+1. `GetIncidentTypes` calls `CatalogRepository.getIncidentTypes` to supply the form dropdown with offline-capable data.
+2. Entities such as `IncidentType` capture requirement flags (evidence, metadata) consumed by controllers.
+
+### Folio Lookup
+1. `LookupFolio` normalizes the folio identifier, then queries `ReportsRepository.lookupFolio` for latest status updates.
+2. The returned `FolioStatus` aggregates a progress history for UI components to display.
+
+## Super-Comment Map
+Super comments annotate validation and delegation steps within use cases:
+- `usecases/authenticate_user.dart`: Provider handoff (`//1.-`).
+- `usecases/submit_report.dart`: Validation and dispatch pipeline (`//1.-`–`//4.-`).
+- `usecases/get_incident_types.dart`: Repository delegation (`//1.-`).
+- `usecases/lookup_folio.dart`: Normalization and lookup (`//1.-`, `//2.-`).

--- a/docs/presentation/README.md
+++ b/docs/presentation/README.md
@@ -1,0 +1,41 @@
+# Presentation Module Overview
+
+## Purpose
+The presentation layer renders UI for public citizens and administrators. It relies on Riverpod controllers from the app layer and domain entities to drive interactive flows such as reporting incidents, checking folios, and managing admin dashboards.
+
+## Key Entry Points
+- [`public/public_shell.dart`](../../lib/src/presentation/public/public_shell.dart): Hosts the public navigation stack.
+- [`public/home/citizen_home_screen.dart`](../../lib/src/presentation/public/home/citizen_home_screen.dart): Landing page exposing primary citizen actions.
+- [`public/map/citizen_map_screen.dart`](../../lib/src/presentation/public/map/citizen_map_screen.dart): Placeholder for geolocation selection before submitting a report.
+- [`public/report/report_form_controller.dart`](../../lib/src/presentation/public/report/report_form_controller.dart) & [`report_form_sheet.dart`](../../lib/src/presentation/public/report/report_form_sheet.dart): Manage the report submission form state and UI surface.
+- [`public/folio_lookup_screen.dart`](../../lib/src/presentation/public/folio_lookup_screen.dart): Enables status lookups for existing folios.
+- [`admin/admin_shell.dart`](../../lib/src/presentation/admin/admin_shell.dart) & [`dashboard/admin_dashboard_screen.dart`](../../lib/src/presentation/admin/dashboard/admin_dashboard_screen.dart): Provide authenticated navigation and dashboard stubs for staff.
+- [`widgets/primary_button.dart`](../../lib/src/presentation/widgets/primary_button.dart): Shared visual component for prominent actions.
+
+## Major Flows
+### Public Incident Reporting
+1. `CitizenHomeScreen` surfaces entry points to start a report or browse other flows.
+2. `CitizenMapScreen` collects a location and triggers the `ReportFormSheet` bottom sheet.
+3. `ReportFormController` loads catalog data, tracks field updates, validates input, and submits via `SubmitReport`.
+4. On success, the controller exposes the created report so UI can confirm the folio back to the citizen.
+
+### Folio Tracking
+1. `FolioLookupScreen` resets local state on each submission, then calls the `LookupFolio` use case through Riverpod providers.
+2. Results or errors are displayed in-line, allowing users to retry with cleaned state when needed.
+
+### Session-Aware Navigation
+1. `CitizenReportsApp` swaps between `PublicShell` and `AdminShell` based on `SessionState`.
+2. Within `PublicShell`, a nested navigator drives map, folio, and home routes without affecting the admin stack.
+3. `AdminShell` offers a scaffold with sign-out actions and quick navigation to `AdminDashboardScreen` summaries.
+
+## Super-Comment Map
+Refer to the following files to align documentation with code annotations:
+- `public/public_shell.dart`: route resolution and nested navigation (`//1.-`).
+- `public/home/citizen_home_screen.dart`: home layout and action prompts (`//1.-`).
+- `public/map/citizen_map_screen.dart`: map container and sheet launch (`//1.-`).
+- `public/report/report_form_controller.dart`: form lifecycle steps (`//1.-`–`//6.-`).
+- `public/report/report_form_sheet.dart`: bottom sheet reactions (`//1.-`, `//2.-`).
+- `public/folio_lookup_screen.dart`: lookup workflow (`//1.-`–`//4.-`).
+- `admin/admin_shell.dart`: admin scaffold and sign-out wiring (`//1.-`).
+- `admin/dashboard/admin_dashboard_screen.dart`: dashboard placeholders (`//1.-`).
+- `widgets/primary_button.dart`: shared button styling (`//1.-`).

--- a/docs/testing/README.md
+++ b/docs/testing/README.md
@@ -1,0 +1,27 @@
+# Testing Overview
+
+## Purpose
+Testing artifacts verify the most critical business flows—report submission validation, repository caching behavior, and widget wiring—without requiring a live backend.
+
+## Key Entry Points
+- [`test/domain/usecases/submit_report_use_case_test.dart`](../../test/domain/usecases/submit_report_use_case_test.dart): Exercises validation and submission logic of the `SubmitReport` use case.
+- [`test/data/reports_repository_impl_test.dart`](../../test/data/reports_repository_impl_test.dart): Covers caching, API fallback, and offline recovery for `ReportsRepositoryImpl`.
+- [`test/widget_test.dart`](../../test/widget_test.dart): Smoke-tests the home screen actions using fake authentication tokens.
+
+## Major Flows
+### Report Validation Guarantees
+1. The submit report use case test stubs the repository, asserts the request payload, and verifies the returned `Report` mirrors domain expectations.
+2. Error scenarios ensure validation exceptions are surfaced when required fields are missing or malformed.
+
+### Repository Offline Strategy
+1. Repository tests seed the in-memory cache, simulate API calls, and ensure remote responses update the cache when successful.
+2. When the API throws, the implementation returns cached data to maintain continuity—mirroring the super-commented fallback steps.
+
+### Widget Entry Points
+1. The widget smoke test bootstraps the app with a known token so `CitizenReportsApp` renders the admin dashboard.
+2. It validates that key public actions remain discoverable through rendered buttons, preserving user journeys described in presentation docs.
+
+## Super-Comment Map
+- `test/data/reports_repository_impl_test.dart`: Highlights cache seeding, remote calls, and fallback assertions (`//1.-`–`//2.-`).
+- `test/domain/usecases/submit_report_use_case_test.dart`: Marks payload verification and fake responses (`//1.-`, `//2.-`).
+- `test/widget_test.dart`: Annotates token setup and widget discovery steps (`//1.-`).


### PR DESCRIPTION
## Summary
- add structured documentation for the app, domain, data, presentation, and testing modules
- explain major flows, entry points, and tie super-commented steps to their implementation files

## Testing
- flutter test *(fails: flutter command not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68e4bb641204832995bc085737e853c9