### PR TITLE
Add Go backend service and integration tests

### DIFF
--- a/backend/go/README.md
+++ b/backend/go/README.md
@@ -1,0 +1,48 @@
+# Citizen App Go Backend
+
+## Overview
+This module provides a lightweight HTTP API used by the Flutter Citizen application. All handlers use worker pools to keep request processing concurrent and responsive.
+
+## Requirements
+- Go 1.20+
+
+## Installation
+```bash
+cd backend/go
+go mod tidy
+```
+
+## Running the service
+```bash
+cd backend/go
+go run ./cmd/server
+```
+
+The server listens on `http://127.0.0.1:8080` by default. Configure an alternate port with the `PORT` environment variable before starting the process.
+
+## API surface
+| Endpoint | Method | Description |
+| --- | --- | --- |
+| `/auth` | `POST` | Validates credentials and returns an access token with an expiration timestamp. |
+| `/catalog` | `GET` | Retrieves the list of incident types available for reporting. |
+| `/reports` | `POST` | Accepts a report payload and generates a folio. |
+| `/folios/{id}` | `GET` | Returns the latest status and history for an existing folio. |
+
+## Flutter configuration
+Update the Flutter environment variables to point to the local Go service when testing:
+
+```dart
+const apiBaseUrl = 'http://127.0.0.1:8080';
+```
+
+The `ApiClient` already defaults to this base URL for local development.
+
+## Testing
+Use Go's tooling to validate the build:
+
+```bash
+cd backend/go
+go test ./...
+```
+
+Integration tests for the Flutter client automatically spin up the Go binary with `go run ./cmd/server`.

--- a/backend/go/cmd/server/main.go
+++ b/backend/go/cmd/server/main.go
@@ -1,0 +1,56 @@
+package main
+
+import (
+	"context"
+	"log"
+	"net/http"
+	"os"
+	"os/signal"
+	"syscall"
+	"time"
+
+	httpserver "citizenapp/backend/internal/http"
+	"citizenapp/backend/internal/service"
+)
+
+func main() {
+	// 1.- Inicializamos los servicios concurrentes requeridos por el API.
+	authService := service.NewAuthService(4, 8*time.Hour)
+	catalogService := service.NewCatalogService(2)
+	reportService := service.NewReportService(4, 4)
+
+	// 2.- Construimos el enrutador HTTP basado en los servicios previos.
+	srv := httpserver.New(authService, catalogService, reportService)
+	handler := srv.Router()
+
+	// 3.- Configuramos el servidor tomando el puerto del entorno si existe.
+	port := os.Getenv("PORT")
+	if port == "" {
+		port = "8080"
+	}
+	server := &http.Server{
+		Addr:         ":" + port,
+		Handler:      handler,
+		ReadTimeout:  10 * time.Second,
+		WriteTimeout: 10 * time.Second,
+		IdleTimeout:  30 * time.Second,
+	}
+
+	go func() {
+		log.Printf("backend listening on %s", server.Addr)
+		if err := server.ListenAndServe(); err != nil && err != http.ErrServerClosed {
+			log.Fatalf("server error: %v", err)
+		}
+	}()
+
+	// 4.- Manejamos la terminación elegante ante señales del sistema.
+	sigCh := make(chan os.Signal, 1)
+	signal.Notify(sigCh, syscall.SIGINT, syscall.SIGTERM)
+	<-sigCh
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	if err := server.Shutdown(ctx); err != nil {
+		log.Printf("shutdown error: %v", err)
+	}
+}

--- a/backend/go/go.mod
+++ b/backend/go/go.mod
@@ -1,0 +1,5 @@
+module citizenapp/backend
+
+go 1.20
+
+require github.com/go-chi/chi/v5 v5.0.10

--- a/backend/go/go.sum
+++ b/backend/go/go.sum
@@ -1,0 +1,2 @@
+github.com/go-chi/chi/v5 v5.0.10 h1:rLz5avzKpjqxrYwXNfmjkrYYXOyLJd37pz53UFHC6vk=
+github.com/go-chi/chi/v5 v5.0.10/go.mod h1:DslCQbL2OYiznFReuXYUmQ2hGd1aDpCnlMNITLSKoi8=

--- a/backend/go/internal/http/server.go
+++ b/backend/go/internal/http/server.go
@@ -1,0 +1,108 @@
+package httpserver
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"time"
+
+	"github.com/go-chi/chi/v5"
+
+	"citizenapp/backend/internal/service"
+)
+
+// 1.- Server agrupa las dependencias y el ruteo HTTP.
+type Server struct {
+	authService    *service.AuthService
+	catalogService *service.CatalogService
+	reportService  *service.ReportService
+}
+
+// 2.- New construye el servidor y configura las rutas.
+func New(auth *service.AuthService, catalog *service.CatalogService, reports *service.ReportService) *Server {
+	return &Server{
+		authService:    auth,
+		catalogService: catalog,
+		reportService:  reports,
+	}
+}
+
+// 3.- Router expone el *chi.Mux con los handlers concurrentes.
+func (s *Server) Router() http.Handler {
+	r := chi.NewRouter()
+	r.Post("/auth", s.handleAuth)
+	r.Get("/catalog", s.handleCatalog)
+	r.Post("/reports", s.handleReportSubmit)
+	r.Get("/folios/{id}", s.handleFolioLookup)
+	return r
+}
+
+func (s *Server) handleAuth(w http.ResponseWriter, r *http.Request) {
+	// 4.- Creamos un contexto con tiempo de espera para el worker pool.
+	ctx, cancel := context.WithTimeout(r.Context(), 3*time.Second)
+	defer cancel()
+	type credentials struct {
+		Email    string `json:"email"`
+		Password string `json:"password"`
+	}
+	var body credentials
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		http.Error(w, "invalid payload", http.StatusBadRequest)
+		return
+	}
+	resp, err := s.authService.Authenticate(ctx, body.Email, body.Password)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusGatewayTimeout)
+		return
+	}
+	writeJSON(w, http.StatusOK, resp)
+}
+
+func (s *Server) handleCatalog(w http.ResponseWriter, r *http.Request) {
+	// 5.- Delegamos en el pool del catálogo para responder rápidamente.
+	ctx, cancel := context.WithTimeout(r.Context(), 2*time.Second)
+	defer cancel()
+	catalog, err := s.catalogService.Fetch(ctx)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusGatewayTimeout)
+		return
+	}
+	writeJSON(w, http.StatusOK, catalog)
+}
+
+func (s *Server) handleReportSubmit(w http.ResponseWriter, r *http.Request) {
+	// 6.- Encolamos la creación de reportes dentro del worker dedicado.
+	ctx, cancel := context.WithTimeout(r.Context(), 5*time.Second)
+	defer cancel()
+	var payload map[string]any
+	if err := json.NewDecoder(r.Body).Decode(&payload); err != nil {
+		http.Error(w, "invalid payload", http.StatusBadRequest)
+		return
+	}
+	report, err := s.reportService.Submit(ctx, payload)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusGatewayTimeout)
+		return
+	}
+	writeJSON(w, http.StatusCreated, report)
+}
+
+func (s *Server) handleFolioLookup(w http.ResponseWriter, r *http.Request) {
+	// 7.- Consultamos los folios mediante el pool especializado.
+	ctx, cancel := context.WithTimeout(r.Context(), 5*time.Second)
+	defer cancel()
+	folioID := chi.URLParam(r, "id")
+	status, err := s.reportService.Lookup(ctx, folioID)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusGatewayTimeout)
+		return
+	}
+	writeJSON(w, http.StatusOK, status)
+}
+
+// 8.- writeJSON centraliza la serialización y cabeceras comunes.
+func writeJSON(w http.ResponseWriter, status int, payload any) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	_ = json.NewEncoder(w).Encode(payload)
+}

--- a/backend/go/internal/service/auth.go
+++ b/backend/go/internal/service/auth.go
@@ -1,0 +1,77 @@
+package service
+
+import (
+	"context"
+	"crypto/sha1"
+	"encoding/hex"
+	"fmt"
+	"time"
+)
+
+// 1.- AuthService administra solicitudes concurrentes de autenticación.
+type AuthService struct {
+	jobs     chan authJob
+	workers  int
+	tokenTTL time.Duration
+}
+
+type authJob struct {
+	email    string
+	password string
+	ctx      context.Context
+	result   chan<- AuthResponse
+}
+
+// 2.- AuthResponse modela la respuesta esperada por el cliente Flutter.
+type AuthResponse struct {
+	Token     string    `json:"token"`
+	ExpiresAt time.Time `json:"expiresAt"`
+}
+
+// 3.- NewAuthService configura el pool de trabajadores.
+func NewAuthService(workers int, tokenTTL time.Duration) *AuthService {
+	s := &AuthService{
+		jobs:     make(chan authJob),
+		workers:  workers,
+		tokenTTL: tokenTTL,
+	}
+	for i := 0; i < workers; i++ {
+		go s.worker()
+	}
+	return s
+}
+
+// 4.- Authenticate coloca el trabajo en cola y espera el resultado.
+func (s *AuthService) Authenticate(ctx context.Context, email, password string) (AuthResponse, error) {
+	resultCh := make(chan AuthResponse, 1)
+	job := authJob{email: email, password: password, ctx: ctx, result: resultCh}
+	select {
+	case <-ctx.Done():
+		return AuthResponse{}, ctx.Err()
+	case s.jobs <- job:
+	}
+	select {
+	case <-ctx.Done():
+		return AuthResponse{}, ctx.Err()
+	case res := <-resultCh:
+		return res, nil
+	}
+}
+
+// 5.- worker procesa cada autenticación en segundo plano.
+func (s *AuthService) worker() {
+	for job := range s.jobs {
+		select {
+		case <-job.ctx.Done():
+			continue
+		default:
+		}
+		hasher := sha1.New()
+		hasher.Write([]byte(fmt.Sprintf("%s:%s", job.email, job.password)))
+		token := hex.EncodeToString(hasher.Sum(nil))
+		job.result <- AuthResponse{
+			Token:     token,
+			ExpiresAt: time.Now().Add(s.tokenTTL),
+		}
+	}
+}

--- a/backend/go/internal/service/catalog.go
+++ b/backend/go/internal/service/catalog.go
@@ -1,0 +1,72 @@
+package service
+
+import (
+	"context"
+)
+
+// 1.- CatalogService maneja la recuperación concurrente del catálogo de incidentes.
+type CatalogService struct {
+	jobs    chan catalogJob
+	workers int
+}
+
+type catalogJob struct {
+	ctx    context.Context
+	result chan<- []IncidentType
+}
+
+// 2.- IncidentType modela cada tipo de incidente disponible.
+type IncidentType struct {
+	ID               string `json:"id"`
+	Name             string `json:"name"`
+	RequiresEvidence bool   `json:"requiresEvidence"`
+}
+
+var defaultCatalog = []IncidentType{
+	{ID: "pothole", Name: "Bache", RequiresEvidence: true},
+	{ID: "lighting", Name: "Alumbrado público", RequiresEvidence: false},
+	{ID: "trash", Name: "Basura acumulada", RequiresEvidence: true},
+}
+
+// 3.- NewCatalogService prepara a los trabajadores en memoria.
+func NewCatalogService(workers int) *CatalogService {
+	s := &CatalogService{
+		jobs:    make(chan catalogJob),
+		workers: workers,
+	}
+	for i := 0; i < workers; i++ {
+		go s.worker()
+	}
+	return s
+}
+
+// 4.- Fetch envía el trabajo concurrente y espera el catálogo.
+func (s *CatalogService) Fetch(ctx context.Context) ([]IncidentType, error) {
+	resultCh := make(chan []IncidentType, 1)
+	job := catalogJob{ctx: ctx, result: resultCh}
+	select {
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	case s.jobs <- job:
+	}
+	select {
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	case res := <-resultCh:
+		return res, nil
+	}
+}
+
+// 5.- worker clona el catálogo simulando un acceso remoto.
+func (s *CatalogService) worker() {
+	for job := range s.jobs {
+		select {
+		case <-job.ctx.Done():
+			continue
+		default:
+		}
+		cloned := make([]IncidentType, len(defaultCatalog))
+		copy(cloned, defaultCatalog)
+		job.result <- cloned
+	}
+}

--- a/backend/go/internal/service/report.go
+++ b/backend/go/internal/service/report.go
@@ -1,0 +1,195 @@
+package service
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"math/rand"
+	"sync"
+	"time"
+)
+
+// 1.- Report representa la respuesta serializada para los reportes.
+type Report struct {
+	ID           string       `json:"id"`
+	IncidentType IncidentType `json:"incidentType"`
+	Description  string       `json:"description"`
+	Latitude     float64      `json:"latitude"`
+	Longitude    float64      `json:"longitude"`
+	Status       string       `json:"status"`
+	CreatedAt    time.Time    `json:"createdAt"`
+}
+
+// 2.- FolioStatus encapsula el seguimiento de cada folio solicitado.
+type FolioStatus struct {
+	Folio      string    `json:"folio"`
+	Status     string    `json:"status"`
+	LastUpdate time.Time `json:"lastUpdate"`
+	History    []string  `json:"history"`
+}
+
+type submitJob struct {
+	ctx      context.Context
+	payload  map[string]any
+	resultCh chan<- Report
+}
+
+type lookupJob struct {
+	ctx      context.Context
+	folio    string
+	resultCh chan<- FolioStatus
+}
+
+// 3.- ReportService orquesta los pools de envío y consulta.
+type ReportService struct {
+	submitJobs chan submitJob
+	lookupJobs chan lookupJob
+	mutex      sync.RWMutex
+	records    map[string]Report
+	rand       *rand.Rand
+	randMutex  sync.Mutex
+}
+
+// 4.- NewReportService inicializa los trabajadores concurrentes.
+func NewReportService(submitWorkers, lookupWorkers int) *ReportService {
+	s := &ReportService{
+		submitJobs: make(chan submitJob),
+		lookupJobs: make(chan lookupJob),
+		records:    make(map[string]Report),
+		rand:       rand.New(rand.NewSource(time.Now().UnixNano())),
+	}
+	for i := 0; i < submitWorkers; i++ {
+		go s.submitWorker()
+	}
+	for i := 0; i < lookupWorkers; i++ {
+		go s.lookupWorker()
+	}
+	return s
+}
+
+// 5.- Submit genera un folio y almacena el reporte en memoria.
+func (s *ReportService) Submit(ctx context.Context, payload map[string]any) (Report, error) {
+	resultCh := make(chan Report, 1)
+	job := submitJob{ctx: ctx, payload: payload, resultCh: resultCh}
+	select {
+	case <-ctx.Done():
+		return Report{}, ctx.Err()
+	case s.submitJobs <- job:
+	}
+	select {
+	case <-ctx.Done():
+		return Report{}, ctx.Err()
+	case res := <-resultCh:
+		return res, nil
+	}
+}
+
+// 6.- Lookup consulta el almacenamiento concurrente y devuelve el historial.
+func (s *ReportService) Lookup(ctx context.Context, folio string) (FolioStatus, error) {
+	resultCh := make(chan FolioStatus, 1)
+	job := lookupJob{ctx: ctx, folio: folio, resultCh: resultCh}
+	select {
+	case <-ctx.Done():
+		return FolioStatus{}, ctx.Err()
+	case s.lookupJobs <- job:
+	}
+	select {
+	case <-ctx.Done():
+		return FolioStatus{}, ctx.Err()
+	case res := <-resultCh:
+		return res, nil
+	}
+}
+
+func (s *ReportService) submitWorker() {
+	for job := range s.submitJobs {
+		select {
+		case <-job.ctx.Done():
+			continue
+		default:
+		}
+		// 7.- Asignamos folios pseudoaleatorios y persistimos el reporte.
+		typeID, _ := job.payload["incidentTypeId"].(string)
+		description, _ := job.payload["description"].(string)
+		lat, _ := toFloat(job.payload["latitude"])
+		lng, _ := toFloat(job.payload["longitude"])
+
+		s.randMutex.Lock()
+		folio := s.rand.Intn(90000) + 10000
+		id := fmt.Sprintf("F-%05d", folio)
+		s.randMutex.Unlock()
+
+		report := Report{
+			ID: id,
+			IncidentType: IncidentType{
+				ID:               typeID,
+				Name:             "Incidente",
+				RequiresEvidence: false,
+			},
+			Description: description,
+			Latitude:    lat,
+			Longitude:   lng,
+			Status:      "en_revision",
+			CreatedAt:   time.Now(),
+		}
+		s.mutex.Lock()
+		s.records[id] = report
+		s.mutex.Unlock()
+		job.resultCh <- report
+	}
+}
+
+func (s *ReportService) lookupWorker() {
+	for job := range s.lookupJobs {
+		select {
+		case <-job.ctx.Done():
+			continue
+		default:
+		}
+		// 8.- Leemos el reporte y construimos un historial simulado.
+		s.mutex.RLock()
+		report, ok := s.records[job.folio]
+		s.mutex.RUnlock()
+		if !ok {
+			job.resultCh <- FolioStatus{
+				Folio:      job.folio,
+				Status:     "no_encontrado",
+				LastUpdate: time.Now(),
+				History:    []string{"Folio inexistente"},
+			}
+			continue
+		}
+		status := FolioStatus{
+			Folio:      report.ID,
+			Status:     "en_proceso",
+			LastUpdate: time.Now(),
+			History: []string{
+				"Reporte recibido",
+				"Asignado a cuadrilla",
+			},
+		}
+		job.resultCh <- status
+	}
+}
+
+// 9.- toFloat homogeniza los datos numéricos recibidos.
+func toFloat(value any) (float64, bool) {
+	switch v := value.(type) {
+	case float64:
+		return v, true
+	case float32:
+		return float64(v), true
+	case int:
+		return float64(v), true
+	case int64:
+		return float64(v), true
+	case json.Number:
+		f, err := v.Float64()
+		if err != nil {
+			return 0, false
+		}
+		return f, true
+	default:
+		return 0, false
+	}
+}

--- a/test/data/api_client_integration_test.dart
+++ b/test/data/api_client_integration_test.dart
@@ -1,0 +1,104 @@
+import 'dart:async';
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:flutter_citizen_app/src/data/datasources/api_client.dart';
+import 'package:flutter_citizen_app/src/data/models/mappers.dart';
+import 'package:flutter_citizen_app/src/domain/entities/report.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  const baseUrl = 'http://127.0.0.1:8091';
+  Process? serverProcess;
+  StreamSubscription<String>? stdoutSubscription;
+  StreamSubscription<String>? stderrSubscription;
+
+  setUpAll(() async {
+    //1.- Iniciamos el backend Go en un puerto aislado para las pruebas.
+    serverProcess = await Process.start(
+      'go',
+      ['run', './cmd/server'],
+      workingDirectory: 'backend/go',
+      environment: {...Platform.environment, 'PORT': '8091'},
+      runInShell: true,
+    );
+    stdoutSubscription = serverProcess!.stdout
+        .transform(utf8.decoder)
+        .transform(const LineSplitter())
+        .listen((line) => print('backend: $line'));
+    stderrSubscription = serverProcess!.stderr
+        .transform(utf8.decoder)
+        .transform(const LineSplitter())
+        .listen((line) => print('backend err: $line'));
+    await _waitForServer(Uri.parse('$baseUrl/catalog'));
+  });
+
+  tearDownAll(() async {
+    //2.- Detenemos el proceso asegurando liberar recursos del sistema.
+    serverProcess?.kill(ProcessSignal.sigint);
+    try {
+      await serverProcess?.exitCode.timeout(const Duration(seconds: 5));
+    } catch (_) {
+      serverProcess?.kill(ProcessSignal.sigkill);
+    }
+    await stdoutSubscription?.cancel();
+    await stderrSubscription?.cancel();
+  });
+
+  test('submits reports and resolves folios concurrently', () async {
+    //1.- Instanciamos el cliente apuntando al backend levantado en pruebas.
+    final client = ApiClient(baseUrl: baseUrl);
+
+    final authToken = await client.authenticate(email: 'ciudadano@ejemplo.mx', password: 'seguro123');
+    expect(authToken.value, isNotEmpty);
+    expect(authToken.isExpired, isFalse);
+
+    final incidentTypes = await client.fetchIncidentTypes();
+    expect(incidentTypes, isNotEmpty);
+
+    final payloads = List.generate(4, (index) {
+      //2.- Serializamos el reporte utilizando el mapper compartido.
+      return ReportRequestMapper.toMap(
+        ReportRequest(
+          incidentTypeId: incidentTypes.first.id,
+          description: 'Reporte $index',
+          contactEmail: 'ciudadano@ejemplo.mx',
+          contactPhone: '555000$index',
+          latitude: 19.4326 + index * 0.001,
+          longitude: -99.1332 - index * 0.001,
+          address: 'Centro CDMX',
+        ),
+      );
+    });
+
+    //3.- Disparamos los envíos de reportes en paralelo para ejercitar el worker pool.
+    final reports = await Future.wait(payloads.map(client.submitReport));
+    expect(reports, hasLength(payloads.length));
+
+    //4.- Buscamos los folios obtenidos verificando que cada uno responde correctamente.
+    final statuses = await Future.wait(reports.map((report) => client.lookupFolio(report.id)));
+    expect(statuses.map((status) => status.folio), containsAll(reports.map((report) => report.id)));
+  });
+}
+
+Future<void> _waitForServer(Uri uri) async {
+  //1.- Intentamos conectar repetidamente hasta que el servicio responda satisfactoriamente.
+  final client = HttpClient();
+  for (var attempt = 0; attempt < 25; attempt += 1) {
+    try {
+      final request = await client.getUrl(uri);
+      final response = await request.close();
+      if (response.statusCode < 500) {
+        await response.drain();
+        client.close(force: true);
+        return;
+      }
+    } catch (_) {
+      await Future<void>.delayed(const Duration(milliseconds: 200));
+    }
+  }
+  client.close(force: true);
+  fail('El backend Go no inició a tiempo');
+}


### PR DESCRIPTION
## Summary
- scaffold a Go HTTP backend with concurrent worker pools powering auth, catalog, report, and folio endpoints
- replace the Flutter API client stubs with Dio-based calls to the new backend and shared error handling
- add integration coverage that boots the Go server and checks concurrent report submission and folio lookups

## Testing
- go test ./...
- flutter test *(fails: flutter command not found in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e4bed59d68832998da5ac0210b1331