### PR TITLE
Add registration, password recovery, and social auth flows

### DIFF
--- a/lib/src/app/providers.dart
+++ b/lib/src/app/providers.dart
@@ -8,6 +8,9 @@ import '../domain/repositories/reports_repository.dart';
 import '../domain/usecases/authenticate_user.dart';
 import '../domain/usecases/get_incident_types.dart';
 import '../domain/usecases/lookup_folio.dart';
+import '../domain/usecases/recover_password.dart';
+import '../domain/usecases/register_user.dart';
+import '../domain/usecases/sign_in_with_provider.dart';
 import '../domain/usecases/submit_report.dart';
 import 'state/session_controller.dart';
 
@@ -39,6 +42,21 @@ final reportsRepositoryProvider = Provider<ReportsRepository>((ref) {
 final authenticateUserProvider = Provider<AuthenticateUser>((ref) {
   //1.- Inyectamos la implementación concreta del repositorio y creamos el caso de uso.
   return AuthenticateUser(authRepository: ref.watch(authRepositoryProvider));
+});
+
+final registerUserProvider = Provider<RegisterUser>((ref) {
+  //1.- Construimos el caso de uso de registro con el repositorio correspondiente.
+  return RegisterUser(authRepository: ref.watch(authRepositoryProvider));
+});
+
+final recoverPasswordProvider = Provider<RecoverPassword>((ref) {
+  //1.- Exponemos la acción de recuperación de contraseña reutilizando el repositorio de autenticación.
+  return RecoverPassword(authRepository: ref.watch(authRepositoryProvider));
+});
+
+final signInWithProviderUseCaseProvider = Provider<SignInWithProvider>((ref) {
+  //1.- Disponemos del caso de uso de autenticación social para los controladores de presentación.
+  return SignInWithProvider(authRepository: ref.watch(authRepositoryProvider));
 });
 
 final submitReportProvider = Provider<SubmitReport>((ref) {

--- a/lib/src/app/state/session_controller.dart
+++ b/lib/src/app/state/session_controller.dart
@@ -50,8 +50,8 @@ class SessionController extends StateNotifier<SessionState> {
     try {
       //2.- Ejecutamos el caso de uso de autenticación utilizando las credenciales entregadas.
       final token = await _authenticateUser(credentials);
-      //3.- Publicamos el token exitoso y marcamos la sesión como autenticada.
-      state = state.copyWith(status: SessionStatus.authenticated, token: token);
+      //3.- Publicamos el token exitoso reutilizando el método dedicado para transicionar la sesión.
+      markAuthenticated(token);
     } on Exception catch (error) {
       //4.- Ante cualquier error exponemos un mensaje legible y limpiamos el token previo.
       state = state.copyWith(
@@ -60,6 +60,15 @@ class SessionController extends StateNotifier<SessionState> {
         token: null,
       );
     }
+  }
+
+  void markAuthenticated(AuthToken token) {
+    //1.- Centralizamos la transición a sesión autenticada para reutilizarla desde otros flujos (registro/social).
+    state = state.copyWith(
+      status: SessionStatus.authenticated,
+      token: token,
+      errorMessage: null,
+    );
   }
 
   void signOut() {

--- a/lib/src/data/datasources/api_client.dart
+++ b/lib/src/data/datasources/api_client.dart
@@ -9,6 +9,7 @@ import '../../domain/entities/incident_type.dart';
 import '../../domain/entities/paginated_reports.dart';
 import '../../domain/entities/report.dart';
 import '../../domain/value_objects/auth_token.dart';
+import '../../domain/value_objects/social_provider.dart';
 // Removed: '../../utils/network/network_executor.dart'
 import '../models/mappers.dart';
 
@@ -46,6 +47,35 @@ class ApiClient {
     await Future<void>.delayed(const Duration(milliseconds: 200));
     return AuthToken(
       'token-${email.hashCode}-${password.hashCode}',
+      expiresAt: DateTime.now().add(const Duration(hours: 8)),
+    );
+  }
+
+  Future<AuthToken> register({
+    required String email,
+    required String password,
+  }) async {
+    await Future<void>.delayed(const Duration(milliseconds: 240));
+    return AuthToken(
+      'reg-${email.hashCode}-${password.hashCode}',
+      expiresAt: DateTime.now().add(const Duration(hours: 8)),
+    );
+  }
+
+  Future<void> recoverPassword({required String email}) async {
+    await Future<void>.delayed(const Duration(milliseconds: 180));
+    if (!email.contains('@')) {
+      throw DioException(
+        requestOptions: RequestOptions(path: '/recover'),
+        message: 'Correo inválido',
+      );
+    }
+  }
+
+  Future<AuthToken> signInWithProvider({required SocialProvider provider}) async {
+    await Future<void>.delayed(const Duration(milliseconds: 210));
+    return AuthToken(
+      'social-${provider.id}-${_random.nextInt(999999)}',
       expiresAt: DateTime.now().add(const Duration(hours: 8)),
     );
   }

--- a/lib/src/domain/repositories/auth_repository.dart
+++ b/lib/src/domain/repositories/auth_repository.dart
@@ -1,6 +1,10 @@
 import '../entities/auth_credentials.dart';
 import '../value_objects/auth_token.dart';
+import '../value_objects/social_provider.dart';
 
 abstract class AuthRepository {
   Future<AuthToken> authenticate(AuthCredentials credentials);
+  Future<AuthToken> register(AuthCredentials credentials);
+  Future<void> recoverPassword(String email);
+  Future<AuthToken> signInWithProvider(SocialProvider provider);
 }

--- a/lib/src/domain/usecases/recover_password.dart
+++ b/lib/src/domain/usecases/recover_password.dart
@@ -1,0 +1,13 @@
+import '../repositories/auth_repository.dart';
+
+class RecoverPassword {
+  const RecoverPassword({required AuthRepository authRepository})
+      : _authRepository = authRepository;
+
+  final AuthRepository _authRepository;
+
+  Future<void> call(String email) {
+    //1.- Solicitamos al repositorio enviar las instrucciones de restablecimiento.
+    return _authRepository.recoverPassword(email);
+  }
+}

--- a/lib/src/domain/usecases/register_user.dart
+++ b/lib/src/domain/usecases/register_user.dart
@@ -1,0 +1,15 @@
+import '../entities/auth_credentials.dart';
+import '../repositories/auth_repository.dart';
+import '../value_objects/auth_token.dart';
+
+class RegisterUser {
+  const RegisterUser({required AuthRepository authRepository})
+      : _authRepository = authRepository;
+
+  final AuthRepository _authRepository;
+
+  Future<AuthToken> call(AuthCredentials credentials) {
+    //1.- Delegamos el registro al repositorio para mantener la lógica de dominio centralizada.
+    return _authRepository.register(credentials);
+  }
+}

--- a/lib/src/domain/usecases/sign_in_with_provider.dart
+++ b/lib/src/domain/usecases/sign_in_with_provider.dart
@@ -1,0 +1,15 @@
+import '../repositories/auth_repository.dart';
+import '../value_objects/auth_token.dart';
+import '../value_objects/social_provider.dart';
+
+class SignInWithProvider {
+  const SignInWithProvider({required AuthRepository authRepository})
+      : _authRepository = authRepository;
+
+  final AuthRepository _authRepository;
+
+  Future<AuthToken> call(SocialProvider provider) {
+    //1.- Delegamos al repositorio la autenticación social para obtener un token interno.
+    return _authRepository.signInWithProvider(provider);
+  }
+}

--- a/lib/src/domain/value_objects/social_provider.dart
+++ b/lib/src/domain/value_objects/social_provider.dart
@@ -1,0 +1,19 @@
+import 'package:equatable/equatable.dart';
+
+enum SocialProvider with EquatableMixin {
+  google('Google'),
+  apple('Apple'),
+  facebook('Facebook');
+
+  const SocialProvider(this.displayName);
+
+  final String displayName;
+
+  String get id {
+    //1.- Reutilizamos el nombre del enumerado para exponer un identificador estable hacia el backend.
+    return name;
+  }
+
+  @override
+  List<Object?> get props => [name];
+}

--- a/lib/src/presentation/public/auth/auth_screen.dart
+++ b/lib/src/presentation/public/auth/auth_screen.dart
@@ -1,0 +1,219 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../../app/state/session_controller.dart';
+import '../../../domain/entities/auth_credentials.dart';
+import '../../../domain/value_objects/social_provider.dart';
+import '../../widgets/primary_button.dart';
+import '../../../app/providers.dart';
+import 'recover_password_controller.dart';
+import 'recover_password_state.dart';
+import 'registration_controller.dart';
+import 'registration_state.dart';
+import 'social_sign_in_controller.dart';
+import 'social_sign_in_state.dart';
+
+class AuthScreen extends ConsumerStatefulWidget {
+  const AuthScreen({super.key});
+
+  @override
+  ConsumerState<AuthScreen> createState() => _AuthScreenState();
+}
+
+class _AuthScreenState extends ConsumerState<AuthScreen> {
+  String _signInEmail = '';
+  String _signInPassword = '';
+
+  void _submitSignIn(SessionController controller) {
+    //1.- Llamamos al controlador global para autenticar con las credenciales capturadas.
+    controller.signIn(AuthCredentials(email: _signInEmail, password: _signInPassword));
+  }
+
+  Widget _buildSection({required String title, required List<Widget> children}) {
+    //1.- Agrupamos cada flujo en una tarjeta consistente para mejorar la lectura.
+    return Card(
+      margin: const EdgeInsets.symmetric(vertical: 12),
+      child: Padding(
+        padding: const EdgeInsets.all(16),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Text(title, style: Theme.of(context).textTheme.titleMedium),
+            const SizedBox(height: 12),
+            ...children,
+          ],
+        ),
+      ),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final sessionState = ref.watch(sessionControllerProvider);
+    final sessionController = ref.read(sessionControllerProvider.notifier);
+    final registrationState = ref.watch(registrationControllerProvider);
+    final registrationController = ref.read(registrationControllerProvider.notifier);
+    final recoverState = ref.watch(recoverPasswordControllerProvider);
+    final recoverController = ref.read(recoverPasswordControllerProvider.notifier);
+    final socialState = ref.watch(socialSignInControllerProvider);
+    final socialController = ref.read(socialSignInControllerProvider.notifier);
+
+    final signInLoading = sessionState.status == SessionStatus.initializing;
+
+    return Scaffold(
+      appBar: AppBar(title: const Text('Acceso administrativo')),
+      body: SingleChildScrollView(
+        padding: const EdgeInsets.all(24),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.stretch,
+          children: [
+            _buildSection(
+              title: 'Iniciar sesión',
+              children: [
+                TextField(
+                  keyboardType: TextInputType.emailAddress,
+                  decoration: const InputDecoration(labelText: 'Correo electrónico'),
+                  onChanged: (value) {
+                    //1.- Guardamos el correo para construir las credenciales al enviar.
+                    setState(() => _signInEmail = value);
+                  },
+                ),
+                const SizedBox(height: 12),
+                TextField(
+                  decoration: const InputDecoration(labelText: 'Contraseña'),
+                  obscureText: true,
+                  onChanged: (value) {
+                    //1.- Persistimos la contraseña en el estado local del widget.
+                    setState(() => _signInPassword = value);
+                  },
+                ),
+                const SizedBox(height: 16),
+                PrimaryButton(
+                  label: signInLoading ? 'Ingresando…' : 'Ingresar',
+                  onPressed: signInLoading ? null : () => _submitSignIn(sessionController),
+                ),
+                if (sessionState.status == SessionStatus.error &&
+                    sessionState.errorMessage != null)
+                  Padding(
+                    padding: const EdgeInsets.only(top: 12),
+                    child: Text(
+                      sessionState.errorMessage!,
+                      style: const TextStyle(color: Colors.red),
+                    ),
+                  ),
+              ],
+            ),
+            _buildSection(
+              title: 'Crear cuenta',
+              children: [
+                TextFormField(
+                  keyboardType: TextInputType.emailAddress,
+                  decoration: const InputDecoration(labelText: 'Correo electrónico'),
+                  initialValue: registrationState.email,
+                  onChanged: registrationController.updateEmail,
+                ),
+                const SizedBox(height: 12),
+                TextFormField(
+                  decoration: const InputDecoration(labelText: 'Contraseña'),
+                  obscureText: true,
+                  initialValue: registrationState.password,
+                  onChanged: registrationController.updatePassword,
+                ),
+                const SizedBox(height: 16),
+                PrimaryButton(
+                  label: registrationState.isLoading ? 'Registrando…' : 'Registrarse',
+                  onPressed:
+                      registrationState.isLoading ? null : () => registrationController.submit(),
+                ),
+                if (registrationState.status == RegistrationStatus.success)
+                  const Padding(
+                    padding: EdgeInsets.only(top: 12),
+                    child: Text('¡Registro completado! Redirigiendo al panel…'),
+                  )
+                else if (registrationState.status == RegistrationStatus.error &&
+                    registrationState.errorMessage != null)
+                  Padding(
+                    padding: const EdgeInsets.only(top: 12),
+                    child: Text(
+                      registrationState.errorMessage!,
+                      style: const TextStyle(color: Colors.red),
+                    ),
+                  ),
+              ],
+            ),
+            _buildSection(
+              title: 'Recuperar contraseña',
+              children: [
+                TextFormField(
+                  keyboardType: TextInputType.emailAddress,
+                  decoration: const InputDecoration(labelText: 'Correo electrónico'),
+                  initialValue: recoverState.email,
+                  onChanged: recoverController.updateEmail,
+                ),
+                const SizedBox(height: 16),
+                PrimaryButton(
+                  label: recoverState.isLoading ? 'Enviando…' : 'Enviar instrucciones',
+                  onPressed: recoverState.isLoading ? null : () => recoverController.submit(),
+                ),
+                if (recoverState.status == RecoverPasswordStatus.success)
+                  const Padding(
+                    padding: EdgeInsets.only(top: 12),
+                    child: Text('Revisa tu bandeja para continuar con el restablecimiento.'),
+                  )
+                else if (recoverState.status == RecoverPasswordStatus.error &&
+                    recoverState.errorMessage != null)
+                  Padding(
+                    padding: const EdgeInsets.only(top: 12),
+                    child: Text(
+                      recoverState.errorMessage!,
+                      style: const TextStyle(color: Colors.red),
+                    ),
+                  ),
+              ],
+            ),
+            _buildSection(
+              title: 'Acceder con redes sociales',
+              children: [
+                Wrap(
+                  spacing: 12,
+                  runSpacing: 12,
+                  children: SocialProvider.values.map((provider) {
+                    return PrimaryButton(
+                      expands: false,
+                      label: provider.displayName,
+                      onPressed: socialState.isLoading
+                          ? null
+                          : () => socialController.signIn(provider),
+                    );
+                  }).toList(),
+                ),
+                if (socialState.isLoading)
+                  const Padding(
+                    padding: EdgeInsets.only(top: 12),
+                    child: LinearProgressIndicator(),
+                  )
+                else if (socialState.status == SocialSignInStatus.success &&
+                    socialState.lastProvider != null)
+                  Padding(
+                    padding: const EdgeInsets.only(top: 12),
+                    child: Text(
+                      'Sesión iniciada con ${socialState.lastProvider!.displayName}.',
+                    ),
+                  )
+                else if (socialState.status == SocialSignInStatus.error &&
+                    socialState.errorMessage != null)
+                  Padding(
+                    padding: const EdgeInsets.only(top: 12),
+                    child: Text(
+                      socialState.errorMessage!,
+                      style: const TextStyle(color: Colors.red),
+                    ),
+                  ),
+              ],
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/src/presentation/public/auth/recover_password_controller.dart
+++ b/lib/src/presentation/public/auth/recover_password_controller.dart
@@ -1,0 +1,41 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../../app/providers.dart';
+import '../../../domain/usecases/recover_password.dart';
+import 'recover_password_state.dart';
+
+final recoverPasswordControllerProvider =
+    StateNotifierProvider.autoDispose<RecoverPasswordController, RecoverPasswordState>((ref) {
+  //1.- Creamos el controlador con el caso de uso que envía los correos de restablecimiento.
+  return RecoverPasswordController(recoverPassword: ref.watch(recoverPasswordProvider));
+});
+
+class RecoverPasswordController extends StateNotifier<RecoverPasswordState> {
+  RecoverPasswordController({required RecoverPassword recoverPassword})
+      : _recoverPassword = recoverPassword,
+        super(const RecoverPasswordState.initial());
+
+  final RecoverPassword _recoverPassword;
+
+  void updateEmail(String value) {
+    //1.- Actualizamos el correo que recibirá las instrucciones de recuperación.
+    state = state.copyWith(email: value);
+  }
+
+  Future<void> submit() async {
+    //1.- Evitamos envíos duplicados en paralelo.
+    if (state.isLoading) {
+      return;
+    }
+    state = state.copyWith(status: RecoverPasswordStatus.loading, errorMessage: null);
+    try {
+      //2.- Invocamos el caso de uso responsable de disparar el correo.
+      await _recoverPassword(state.email);
+      //3.- Mostramos al usuario que el mensaje fue enviado exitosamente.
+      state = state.copyWith(status: RecoverPasswordStatus.success, errorMessage: null);
+    } on Exception catch (error) {
+      //4.- Registramos la falla para que la interfaz muestre el mensaje correspondiente.
+      state = state.copyWith(status: RecoverPasswordStatus.error, errorMessage: error.toString());
+    }
+  }
+}

--- a/lib/src/presentation/public/auth/recover_password_state.dart
+++ b/lib/src/presentation/public/auth/recover_password_state.dart
@@ -1,0 +1,42 @@
+import 'package:equatable/equatable.dart';
+
+enum RecoverPasswordStatus { idle, loading, success, error }
+
+class RecoverPasswordState extends Equatable {
+  const RecoverPasswordState({
+    required this.email,
+    required this.status,
+    this.errorMessage,
+  });
+
+  const RecoverPasswordState.initial()
+      : this(
+          email: '',
+          status: RecoverPasswordStatus.idle,
+        );
+
+  final String email;
+  final RecoverPasswordStatus status;
+  final String? errorMessage;
+
+  bool get isLoading {
+    //1.- Indicamos si debemos bloquear el botón mientras se procesa el envío.
+    return status == RecoverPasswordStatus.loading;
+  }
+
+  RecoverPasswordState copyWith({
+    String? email,
+    RecoverPasswordStatus? status,
+    String? errorMessage,
+  }) {
+    //1.- Generamos un nuevo estado sin mutar el actual para mantener la trazabilidad.
+    return RecoverPasswordState(
+      email: email ?? this.email,
+      status: status ?? this.status,
+      errorMessage: errorMessage,
+    );
+  }
+
+  @override
+  List<Object?> get props => [email, status, errorMessage];
+}

--- a/lib/src/presentation/public/auth/registration_controller.dart
+++ b/lib/src/presentation/public/auth/registration_controller.dart
@@ -1,0 +1,58 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../../app/providers.dart';
+import '../../../app/state/session_controller.dart';
+import '../../../domain/entities/auth_credentials.dart';
+import '../../../domain/usecases/register_user.dart';
+import 'registration_state.dart';
+
+final registrationControllerProvider =
+    StateNotifierProvider.autoDispose<RegistrationController, RegistrationState>((ref) {
+  //1.- Creamos el controlador inyectando el caso de uso y el manejador de sesión.
+  final controller = RegistrationController(
+    registerUser: ref.watch(registerUserProvider),
+    sessionController: ref.read(sessionControllerProvider.notifier),
+  );
+  return controller;
+});
+
+class RegistrationController extends StateNotifier<RegistrationState> {
+  RegistrationController({required RegisterUser registerUser, required SessionController sessionController})
+      : _registerUser = registerUser,
+        _sessionController = sessionController,
+        super(const RegistrationState.initial());
+
+  final RegisterUser _registerUser;
+  final SessionController _sessionController;
+
+  void updateEmail(String value) {
+    //1.- Guardamos el correo capturado para construir las credenciales.
+    state = state.copyWith(email: value);
+  }
+
+  void updatePassword(String value) {
+    //1.- Sincronizamos la contraseña escrita con el estado observable.
+    state = state.copyWith(password: value);
+  }
+
+  Future<void> submit() async {
+    //1.- Evitamos procesar múltiples envíos mientras un registro sigue en curso.
+    if (state.isLoading) {
+      return;
+    }
+    state = state.copyWith(status: RegistrationStatus.loading, errorMessage: null);
+    try {
+      //2.- Ejecutamos el caso de uso enviando las credenciales capturadas.
+      final token = await _registerUser(
+        AuthCredentials(email: state.email, password: state.password),
+      );
+      //3.- Notificamos a la sesión principal para navegar automáticamente al panel administrativo.
+      _sessionController.markAuthenticated(token);
+      //4.- Actualizamos el estado indicando éxito y limpiando mensajes previos.
+      state = state.copyWith(status: RegistrationStatus.success, errorMessage: null);
+    } on Exception catch (error) {
+      //5.- Exponemos el error recibido sin alterar las credenciales ingresadas.
+      state = state.copyWith(status: RegistrationStatus.error, errorMessage: error.toString());
+    }
+  }
+}

--- a/lib/src/presentation/public/auth/registration_state.dart
+++ b/lib/src/presentation/public/auth/registration_state.dart
@@ -1,0 +1,47 @@
+import 'package:equatable/equatable.dart';
+
+enum RegistrationStatus { idle, loading, success, error }
+
+class RegistrationState extends Equatable {
+  const RegistrationState({
+    required this.email,
+    required this.password,
+    required this.status,
+    this.errorMessage,
+  });
+
+  const RegistrationState.initial()
+      : this(
+          email: '',
+          password: '',
+          status: RegistrationStatus.idle,
+        );
+
+  final String email;
+  final String password;
+  final RegistrationStatus status;
+  final String? errorMessage;
+
+  bool get isLoading {
+    //1.- Verificamos si el flujo se encuentra procesando una petición remota.
+    return status == RegistrationStatus.loading;
+  }
+
+  RegistrationState copyWith({
+    String? email,
+    String? password,
+    RegistrationStatus? status,
+    String? errorMessage,
+  }) {
+    //1.- Retornamos una nueva instancia asegurando inmutabilidad en los controladores.
+    return RegistrationState(
+      email: email ?? this.email,
+      password: password ?? this.password,
+      status: status ?? this.status,
+      errorMessage: errorMessage,
+    );
+  }
+
+  @override
+  List<Object?> get props => [email, password, status, errorMessage];
+}

--- a/lib/src/presentation/public/auth/social_sign_in_controller.dart
+++ b/lib/src/presentation/public/auth/social_sign_in_controller.dart
@@ -1,0 +1,51 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../../app/providers.dart';
+import '../../../app/state/session_controller.dart';
+import '../../../domain/usecases/sign_in_with_provider.dart';
+import '../../../domain/value_objects/social_provider.dart';
+import 'social_sign_in_state.dart';
+
+final socialSignInControllerProvider =
+    StateNotifierProvider.autoDispose<SocialSignInController, SocialSignInState>((ref) {
+  //1.- Creamos el controlador social reutilizando el caso de uso y la sesión global.
+  return SocialSignInController(
+    signInWithProvider: ref.watch(signInWithProviderUseCaseProvider),
+    sessionController: ref.read(sessionControllerProvider.notifier),
+  );
+});
+
+class SocialSignInController extends StateNotifier<SocialSignInState> {
+  SocialSignInController({
+    required SignInWithProvider signInWithProvider,
+    required SessionController sessionController,
+  })  : _signInWithProvider = signInWithProvider,
+        _sessionController = sessionController,
+        super(const SocialSignInState.initial());
+
+  final SignInWithProvider _signInWithProvider;
+  final SessionController _sessionController;
+
+  Future<void> signIn(SocialProvider provider) async {
+    //1.- Evitamos solicitudes múltiples al mismo tiempo para proteger al backend.
+    if (state.isLoading) {
+      return;
+    }
+    state = state.copyWith(
+      status: SocialSignInStatus.loading,
+      errorMessage: null,
+      lastProvider: provider,
+    );
+    try {
+      //2.- Solicitamos al backend autenticarse con el proveedor especificado.
+      final token = await _signInWithProvider(provider);
+      //3.- Notificamos al controlador de sesión para navegar inmediatamente al entorno administrativo.
+      _sessionController.markAuthenticated(token);
+      //4.- Registramos el éxito para mostrar retroalimentación en la interfaz.
+      state = state.copyWith(status: SocialSignInStatus.success, errorMessage: null);
+    } on Exception catch (error) {
+      //5.- Mantenemos el proveedor que falló y exponemos el mensaje de error.
+      state = state.copyWith(status: SocialSignInStatus.error, errorMessage: error.toString());
+    }
+  }
+}

--- a/lib/src/presentation/public/auth/social_sign_in_state.dart
+++ b/lib/src/presentation/public/auth/social_sign_in_state.dart
@@ -1,0 +1,41 @@
+import 'package:equatable/equatable.dart';
+
+import '../../../domain/value_objects/social_provider.dart';
+
+enum SocialSignInStatus { idle, loading, success, error }
+
+class SocialSignInState extends Equatable {
+  const SocialSignInState({
+    required this.status,
+    this.errorMessage,
+    this.lastProvider,
+  });
+
+  const SocialSignInState.initial()
+      : this(status: SocialSignInStatus.idle);
+
+  final SocialSignInStatus status;
+  final String? errorMessage;
+  final SocialProvider? lastProvider;
+
+  bool get isLoading {
+    //1.- Indicamos cuando se está validando un proveedor para bloquear nuevos intentos.
+    return status == SocialSignInStatus.loading;
+  }
+
+  SocialSignInState copyWith({
+    SocialSignInStatus? status,
+    String? errorMessage,
+    SocialProvider? lastProvider,
+  }) {
+    //1.- Reemplazamos selectivamente los valores para propagar el nuevo estado a la UI.
+    return SocialSignInState(
+      status: status ?? this.status,
+      errorMessage: errorMessage,
+      lastProvider: lastProvider ?? this.lastProvider,
+    );
+  }
+
+  @override
+  List<Object?> get props => [status, errorMessage, lastProvider];
+}

--- a/lib/src/presentation/public/home/citizen_home_screen.dart
+++ b/lib/src/presentation/public/home/citizen_home_screen.dart
@@ -34,20 +34,8 @@ class CitizenHomeScreen extends StatelessWidget {
             const Spacer(),
             TextButton(
               onPressed: () {
-                //1.- Mostraríamos el formulario de login dentro de un bottom sheet.
-                showDialog<void>(
-                  context: context,
-                  builder: (context) => AlertDialog(
-                    title: const Text('Acceso administrativo'),
-                    content: const Text('Integra aquí el formulario de autenticación.'),
-                    actions: [
-                      TextButton(
-                        onPressed: () => Navigator.of(context).pop(),
-                        child: const Text('Cerrar'),
-                      ),
-                    ],
-                  ),
-                );
+                //1.- Navegamos a la nueva pantalla de autenticación administrada por Riverpod.
+                Navigator.of(context).pushNamed('/auth');
               },
               child: const Text('Ingresar como administrador'),
             ),

--- a/lib/src/presentation/public/public_shell.dart
+++ b/lib/src/presentation/public/public_shell.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 
+import 'auth/auth_screen.dart';
 import 'folio_lookup_screen.dart';
 import 'home/citizen_home_screen.dart';
 import 'map/citizen_map_screen.dart';
@@ -21,6 +22,8 @@ class _PublicShellState extends State<PublicShell> {
         return MaterialPageRoute(builder: (_) => const CitizenMapScreen());
       case '/folio':
         return MaterialPageRoute(builder: (_) => const FolioLookupScreen());
+      case '/auth':
+        return MaterialPageRoute(builder: (_) => const AuthScreen());
       default:
         return MaterialPageRoute(builder: (_) => const CitizenHomeScreen());
     }

--- a/test/presentation/auth/fake_auth_repository.dart
+++ b/test/presentation/auth/fake_auth_repository.dart
@@ -1,0 +1,54 @@
+import 'package:citizen_reports_flutter/src/domain/entities/auth_credentials.dart';
+import 'package:citizen_reports_flutter/src/domain/repositories/auth_repository.dart';
+import 'package:citizen_reports_flutter/src/domain/value_objects/auth_token.dart';
+import 'package:citizen_reports_flutter/src/domain/value_objects/social_provider.dart';
+
+class FakeAuthRepository implements AuthRepository {
+  FakeAuthRepository();
+
+  AuthToken authenticateReturn = AuthToken(
+    'auth-token',
+    expiresAt: DateTime.now().add(const Duration(hours: 8)),
+  );
+  AuthToken? registerReturn;
+  AuthToken? providerReturn;
+  Exception? registerError;
+  Exception? providerError;
+  Exception? recoverError;
+  String? lastRecoveredEmail;
+  SocialProvider? lastProvider;
+
+  @override
+  Future<AuthToken> authenticate(AuthCredentials credentials) async {
+    //1.- Retornamos un token por defecto para permitir instanciar el SessionController durante las pruebas.
+    return authenticateReturn;
+  }
+
+  @override
+  Future<AuthToken> register(AuthCredentials credentials) async {
+    //1.- Simulamos tanto rutas exitosas como fallidas según la configuración del test.
+    if (registerError != null) {
+      throw registerError!;
+    }
+    return registerReturn ?? authenticateReturn;
+  }
+
+  @override
+  Future<void> recoverPassword(String email) async {
+    //1.- Guardamos el correo para poder aseverar que se llamó al repositorio.
+    lastRecoveredEmail = email;
+    if (recoverError != null) {
+      throw recoverError!;
+    }
+  }
+
+  @override
+  Future<AuthToken> signInWithProvider(SocialProvider provider) async {
+    //1.- Permitimos que la prueba fuerce tanto éxitos como errores controlados.
+    lastProvider = provider;
+    if (providerError != null) {
+      throw providerError!;
+    }
+    return providerReturn ?? authenticateReturn;
+  }
+}

--- a/test/presentation/auth/recover_password_controller_test.dart
+++ b/test/presentation/auth/recover_password_controller_test.dart
@@ -1,0 +1,39 @@
+import 'package:citizen_reports_flutter/src/domain/usecases/recover_password.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'fake_auth_repository.dart';
+import 'package:citizen_reports_flutter/src/presentation/public/auth/recover_password_controller.dart';
+import 'package:citizen_reports_flutter/src/presentation/public/auth/recover_password_state.dart';
+
+void main() {
+  group('RecoverPasswordController', () {
+    test('emits success state when email is sent', () async {
+      //1.- Preparamos el repositorio para registrar el correo procesado.
+      final repository = FakeAuthRepository();
+      final controller = RecoverPasswordController(
+        recoverPassword: RecoverPassword(authRepository: repository),
+      );
+
+      controller.updateEmail('user@example.com');
+      await controller.submit();
+
+      expect(repository.lastRecoveredEmail, 'user@example.com');
+      expect(controller.state.status, RecoverPasswordStatus.success);
+      expect(controller.state.errorMessage, isNull);
+    });
+
+    test('emits error state when repository throws', () async {
+      //1.- Configuramos el repositorio para lanzar un fallo controlado.
+      final repository = FakeAuthRepository()..recoverError = Exception('offline');
+      final controller = RecoverPasswordController(
+        recoverPassword: RecoverPassword(authRepository: repository),
+      );
+
+      controller.updateEmail('user@example.com');
+      await controller.submit();
+
+      expect(controller.state.status, RecoverPasswordStatus.error);
+      expect(controller.state.errorMessage, contains('offline'));
+    });
+  });
+}

--- a/test/presentation/auth/registration_controller_test.dart
+++ b/test/presentation/auth/registration_controller_test.dart
@@ -1,0 +1,57 @@
+import 'package:citizen_reports_flutter/src/app/state/session_controller.dart';
+import 'package:citizen_reports_flutter/src/domain/usecases/authenticate_user.dart';
+import 'package:citizen_reports_flutter/src/domain/usecases/register_user.dart';
+import 'package:citizen_reports_flutter/src/domain/value_objects/auth_token.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'fake_auth_repository.dart';
+import 'package:citizen_reports_flutter/src/presentation/public/auth/registration_controller.dart';
+import 'package:citizen_reports_flutter/src/presentation/public/auth/registration_state.dart';
+
+void main() {
+  group('RegistrationController', () {
+    test('marks session as authenticated on successful registration', () async {
+      //1.- Configuramos el repositorio falso para devolver un token válido durante el registro.
+      final repository = FakeAuthRepository()
+        ..registerReturn = AuthToken('reg', expiresAt: DateTime.now().add(const Duration(hours: 1)));
+      final sessionController = SessionController(
+        authenticateUser: AuthenticateUser(authRepository: repository),
+      );
+      final controller = RegistrationController(
+        registerUser: RegisterUser(authRepository: repository),
+        sessionController: sessionController,
+      );
+
+      controller.updateEmail('admin@example.com');
+      controller.updatePassword('secret');
+
+      await controller.submit();
+
+      expect(controller.state.status, RegistrationStatus.success);
+      expect(sessionController.state.status, SessionStatus.authenticated);
+      expect(sessionController.state.token?.value, 'reg');
+    });
+
+    test('emits error state when repository fails', () async {
+      //1.- Inyectamos una excepción para validar que el controlador la propaga correctamente.
+      final repository = FakeAuthRepository()
+        ..registerError = Exception('network');
+      final sessionController = SessionController(
+        authenticateUser: AuthenticateUser(authRepository: repository),
+      );
+      final controller = RegistrationController(
+        registerUser: RegisterUser(authRepository: repository),
+        sessionController: sessionController,
+      );
+
+      controller.updateEmail('admin@example.com');
+      controller.updatePassword('secret');
+
+      await controller.submit();
+
+      expect(controller.state.status, RegistrationStatus.error);
+      expect(controller.state.errorMessage, contains('network'));
+      expect(sessionController.state.status, SessionStatus.signedOut);
+    });
+  });
+}

--- a/test/presentation/auth/social_sign_in_controller_test.dart
+++ b/test/presentation/auth/social_sign_in_controller_test.dart
@@ -1,0 +1,54 @@
+import 'package:citizen_reports_flutter/src/app/state/session_controller.dart';
+import 'package:citizen_reports_flutter/src/domain/usecases/authenticate_user.dart';
+import 'package:citizen_reports_flutter/src/domain/usecases/sign_in_with_provider.dart';
+import 'package:citizen_reports_flutter/src/domain/value_objects/auth_token.dart';
+import 'package:citizen_reports_flutter/src/domain/value_objects/social_provider.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'fake_auth_repository.dart';
+import 'package:citizen_reports_flutter/src/presentation/public/auth/social_sign_in_controller.dart';
+import 'package:citizen_reports_flutter/src/presentation/public/auth/social_sign_in_state.dart';
+
+void main() {
+  group('SocialSignInController', () {
+    test('propagates token to session on success', () async {
+      //1.- Preparamos el repositorio para devolver un token social exitoso.
+      final repository = FakeAuthRepository()
+        ..providerReturn = AuthToken('social', expiresAt: DateTime.now().add(const Duration(hours: 1)));
+      final sessionController = SessionController(
+        authenticateUser: AuthenticateUser(authRepository: repository),
+      );
+      final controller = SocialSignInController(
+        signInWithProvider: SignInWithProvider(authRepository: repository),
+        sessionController: sessionController,
+      );
+
+      await controller.signIn(SocialProvider.google);
+
+      expect(controller.state.status, SocialSignInStatus.success);
+      expect(controller.state.lastProvider, SocialProvider.google);
+      expect(sessionController.state.status, SessionStatus.authenticated);
+      expect(sessionController.state.token?.value, 'social');
+    });
+
+    test('exposes error when sign-in fails', () async {
+      //1.- Forzamos un error desde el repositorio social.
+      final repository = FakeAuthRepository()
+        ..providerError = Exception('rejected');
+      final sessionController = SessionController(
+        authenticateUser: AuthenticateUser(authRepository: repository),
+      );
+      final controller = SocialSignInController(
+        signInWithProvider: SignInWithProvider(authRepository: repository),
+        sessionController: sessionController,
+      );
+
+      await controller.signIn(SocialProvider.apple);
+
+      expect(controller.state.status, SocialSignInStatus.error);
+      expect(controller.state.errorMessage, contains('rejected'));
+      expect(controller.state.lastProvider, SocialProvider.apple);
+      expect(sessionController.state.status, SessionStatus.signedOut);
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- extend the authentication repository and API client with register, password recovery, and provider sign-in capabilities
- add domain use cases plus public controllers and UI for registration, recovery, and social auth screens wired into the session flow
- cover the new controllers with fake-backed unit tests for success and error handling

## Testing
- unable to run `flutter test` (command not found in container)

