### PR TITLE
Integrate Google Maps selection screen

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -4,6 +4,9 @@
         android:name="${applicationName}"
         android:icon="@drawable/ic_launcher_foreground"
         android:roundIcon="@drawable/ic_launcher_foreground">
+        <meta-data
+            android:name="com.google.android.geo.API_KEY"
+            android:value="@string/google_maps_api_key" />
         <activity
             android:name=".MainActivity"
             android:exported="true"

--- a/android/app/src/main/res/values/google_maps_api.xml
+++ b/android/app/src/main/res/values/google_maps_api.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="google_maps_api_key">YOUR_ANDROID_GOOGLE_MAPS_API_KEY</string>
+</resources>

--- a/ios/Runner/AppDelegate.swift
+++ b/ios/Runner/AppDelegate.swift
@@ -1,4 +1,5 @@
 import Flutter
+import GoogleMaps
 import UIKit
 
 @main
@@ -7,6 +8,7 @@ import UIKit
     _ application: UIApplication,
     didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?
   ) -> Bool {
+    GMSServices.provideAPIKey("YOUR_IOS_GOOGLE_MAPS_API_KEY")
     GeneratedPluginRegistrant.register(with: self)
     return super.application(application, didFinishLaunchingWithOptions: launchOptions)
   }

--- a/lib/src/presentation/public/map/citizen_map_screen.dart
+++ b/lib/src/presentation/public/map/citizen_map_screen.dart
@@ -1,40 +1,89 @@
 import 'package:flutter/material.dart';
+import 'package:google_maps_flutter/google_maps_flutter.dart';
 
 import '../report/report_form_sheet.dart';
 
-class CitizenMapScreen extends StatelessWidget {
-  const CitizenMapScreen({super.key});
+class CitizenMapScreen extends StatefulWidget {
+  const CitizenMapScreen({
+    super.key,
+    this.initialCameraPosition = const CameraPosition(
+      target: LatLng(0, 0),
+      zoom: 21,
+    ),
+    this.onLocationSelected,
+  });
+
+  final CameraPosition initialCameraPosition;
+  final ValueChanged<LatLng>? onLocationSelected;
+
+  @override
+  State<CitizenMapScreen> createState() => _CitizenMapScreenState();
+}
+
+class _CitizenMapScreenState extends State<CitizenMapScreen> {
+  LatLng? _selectedLocation;
+
+  @override
+  void initState() {
+    super.initState();
+    //1.- Guardamos la posición inicial para mostrar un marcador desde el arranque.
+    _selectedLocation = widget.initialCameraPosition.target;
+  }
+
+  void _handleMapTap(LatLng position) {
+    //2.- Actualizamos el marcador y notificamos a las capas superiores cuando se selecciona una ubicación.
+    setState(() {
+      _selectedLocation = position;
+    });
+    widget.onLocationSelected?.call(position);
+  }
+
+  void _handleConfirmLocation() {
+    final LatLng confirmedLocation =
+        _selectedLocation ?? widget.initialCameraPosition.target;
+    //3.- Disparamos el callback final y mostramos el formulario de reporte en un bottom sheet.
+    widget.onLocationSelected?.call(confirmedLocation);
+    showModalBottomSheet<void>(
+      context: context,
+      isScrollControlled: true,
+      builder: (_) => const ReportFormSheet(),
+    );
+  }
 
   @override
   Widget build(BuildContext context) {
-    //1.- Renderizamos un contenedor que simula el mapa y permite confirmar la ubicación.
+    //4.- Renderizamos el mapa de Google y el botón de confirmación de la ubicación.
     return Scaffold(
       appBar: AppBar(title: const Text('Selecciona la ubicación')),
       body: Column(
         children: [
           Expanded(
-            child: Container(
-              margin: const EdgeInsets.all(16),
-              decoration: BoxDecoration(
-                color: Colors.blueGrey.shade100,
+            child: Padding(
+              padding: const EdgeInsets.all(16),
+              child: ClipRRect(
                 borderRadius: BorderRadius.circular(16),
-              ),
-              child: const Center(
-                child: Text('Mapa ciudadano (Google Maps Compose equivalente)'),
+                child: GoogleMap(
+                  initialCameraPosition: widget.initialCameraPosition,
+                  minMaxZoomPreference: const MinMaxZoomPreference(0, 21),
+                  myLocationButtonEnabled: false,
+                  myLocationEnabled: false,
+                  zoomControlsEnabled: false,
+                  onTap: _handleMapTap,
+                  markers: {
+                    if (_selectedLocation != null)
+                      Marker(
+                        markerId: const MarkerId('selected_location'),
+                        position: _selectedLocation!,
+                      ),
+                  },
+                ),
               ),
             ),
           ),
           Padding(
             padding: const EdgeInsets.all(16),
             child: ElevatedButton.icon(
-              onPressed: () {
-                //1.- Mostramos el formulario en un bottom sheet similar a la web actual.
-                showModalBottomSheet<void>(
-                  context: context,
-                  isScrollControlled: true,
-                  builder: (_) => const ReportFormSheet(),
-                );
-              },
+              onPressed: _handleConfirmLocation,
               icon: const Icon(Icons.check_circle_outline),
               label: const Padding(
                 padding: EdgeInsets.symmetric(vertical: 12),

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -73,6 +73,46 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.0.7"
+  google_maps_flutter:
+    dependency: "direct main"
+    description:
+      name: google_maps_flutter
+      sha256: c389e16fafc04b37a4105e0757ecb9d59806026cee72f408f1ba68811d01bfe6
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.13.1"
+  google_maps_flutter_android:
+    dependency: transitive
+    description:
+      name: google_maps_flutter_android
+      sha256: ab83128296fbeaa52e8f2b3bf53bcd895e64778edddcdc07bc8f33f4ea78076c
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.16.1"
+  google_maps_flutter_ios:
+    dependency: transitive
+    description:
+      name: google_maps_flutter_ios
+      sha256: d03678415da9de8ce7208c674b264fc75946f326e696b4b7f84c80920fc58df6
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.15.4"
+  google_maps_flutter_platform_interface:
+    dependency: transitive
+    description:
+      name: google_maps_flutter_platform_interface
+      sha256: f4b9b44f7b12a1f6707ffc79d082738e0b7e194bf728ee61d2b3cdf5fdf16081
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.14.0"
+  google_maps_flutter_web:
+    dependency: transitive
+    description:
+      name: google_maps_flutter_web
+      sha256: 68baf1e22428875f3c2781110a9bb25fddbbc2bff1be867a3cd667c3f816ae04
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.5.14"
   fake_async:
     dependency: transitive
     description:
@@ -187,6 +227,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.9.1"
+  plugin_platform_interface:
+    dependency: transitive
+    description:
+      name: plugin_platform_interface
+      sha256: 4820fbfdb9478b1ebae27888254d445073732dae3d6ea81f0b7e06d5dedc3f02
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.1.8"
   riverpod:
     dependency: transitive
     description:
@@ -232,6 +280,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.1.4"
+  stream_transform:
+    dependency: transitive
+    description:
+      name: stream_transform
+      sha256: ad47125e588cfd37a9a7f86c7d6356dde8dfe89d071d293f80ca9e9273a33871
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.1.1"
   string_scanner:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -37,6 +37,7 @@ dependencies:
   flutter_riverpod: ^2.5.1
   dio: ^5.7.0
   equatable: ^2.0.5
+  google_maps_flutter: ^2.13.1
 
 dev_dependencies:
   flutter_test:

--- a/test/presentation/public/citizen_map_screen_test.dart
+++ b/test/presentation/public/citizen_map_screen_test.dart
@@ -1,0 +1,250 @@
+import 'dart:typed_data';
+
+import 'package:citizen_reports_flutter/src/presentation/public/map/citizen_map_screen.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:google_maps_flutter/google_maps_flutter.dart';
+import 'package:google_maps_flutter_platform_interface/google_maps_flutter_platform_interface.dart';
+
+class _FakeGoogleMapsFlutterPlatform extends GoogleMapsFlutterPlatform {
+  CameraPosition? lastCameraPosition;
+
+  @override
+  Future<void> init(int mapId) async {}
+
+  @override
+  Widget buildViewWithConfiguration(
+    int creationId,
+    PlatformViewCreatedCallback onPlatformViewCreated, {
+    required MapWidgetConfiguration widgetConfiguration,
+    MapConfiguration mapConfiguration = const MapConfiguration(),
+    MapObjects mapObjects = const MapObjects(),
+  }) {
+    lastCameraPosition = widgetConfiguration.initialCameraPosition;
+    onPlatformViewCreated(creationId);
+    return const SizedBox();
+  }
+
+  @override
+  Future<void> updateMapConfiguration(
+    MapConfiguration configuration, {
+    required int mapId,
+  }) async {}
+
+  @override
+  Future<void> updateMarkers(
+    MarkerUpdates markerUpdates, {
+    required int mapId,
+  }) async {}
+
+  @override
+  Future<void> updatePolygons(
+    PolygonUpdates polygonUpdates, {
+    required int mapId,
+  }) async {}
+
+  @override
+  Future<void> updatePolylines(
+    PolylineUpdates polylineUpdates, {
+    required int mapId,
+  }) async {}
+
+  @override
+  Future<void> updateCircles(
+    CircleUpdates circleUpdates, {
+    required int mapId,
+  }) async {}
+
+  @override
+  Future<void> updateTileOverlays({
+    required Set<TileOverlay> newTileOverlays,
+    required int mapId,
+  }) async {}
+
+  @override
+  Future<void> clearTileCache(
+    TileOverlayId tileOverlayId, {
+    required int mapId,
+  }) async {}
+
+  @override
+  Future<void> animateCamera(
+    CameraUpdate cameraUpdate, {
+    required int mapId,
+  }) async {}
+
+  @override
+  Future<void> moveCamera(
+    CameraUpdate cameraUpdate, {
+    required int mapId,
+  }) async {}
+
+  @override
+  Future<void> setMapStyle(
+    String? mapStyle, {
+    required int mapId,
+  }) async {}
+
+  @override
+  Future<LatLngBounds> getVisibleRegion({
+    required int mapId,
+  }) async {
+    return const LatLngBounds(
+      southwest: LatLng(0, 0),
+      northeast: LatLng(0, 0),
+    );
+  }
+
+  @override
+  Future<ScreenCoordinate> getScreenCoordinate(
+    LatLng latLng, {
+    required int mapId,
+  }) async {
+    return const ScreenCoordinate(x: 0, y: 0);
+  }
+
+  @override
+  Future<LatLng> getLatLng(
+    ScreenCoordinate screenCoordinate, {
+    required int mapId,
+  }) async {
+    return const LatLng(0, 0);
+  }
+
+  @override
+  Future<void> showMarkerInfoWindow(
+    MarkerId markerId, {
+    required int mapId,
+  }) async {}
+
+  @override
+  Future<void> hideMarkerInfoWindow(
+    MarkerId markerId, {
+    required int mapId,
+  }) async {}
+
+  @override
+  Future<bool> isMarkerInfoWindowShown(
+    MarkerId markerId, {
+    required int mapId,
+  }) async {
+    return false;
+  }
+
+  @override
+  Future<double> getZoomLevel({
+    required int mapId,
+  }) async {
+    return lastCameraPosition?.zoom ?? 0;
+  }
+
+  @override
+  Future<Uint8List?> takeSnapshot({
+    required int mapId,
+  }) async {
+    return null;
+  }
+
+  @override
+  Stream<CameraMoveStartedEvent> onCameraMoveStarted({required int mapId}) {
+    return const Stream<CameraMoveStartedEvent>.empty();
+  }
+
+  @override
+  Stream<CameraMoveEvent> onCameraMove({required int mapId}) {
+    return const Stream<CameraMoveEvent>.empty();
+  }
+
+  @override
+  Stream<CameraIdleEvent> onCameraIdle({required int mapId}) {
+    return const Stream<CameraIdleEvent>.empty();
+  }
+
+  @override
+  Stream<MarkerTapEvent> onMarkerTap({required int mapId}) {
+    return const Stream<MarkerTapEvent>.empty();
+  }
+
+  @override
+  Stream<MarkerDragStartEvent> onMarkerDragStart({required int mapId}) {
+    return const Stream<MarkerDragStartEvent>.empty();
+  }
+
+  @override
+  Stream<MarkerDragEvent> onMarkerDrag({required int mapId}) {
+    return const Stream<MarkerDragEvent>.empty();
+  }
+
+  @override
+  Stream<MarkerDragEndEvent> onMarkerDragEnd({required int mapId}) {
+    return const Stream<MarkerDragEndEvent>.empty();
+  }
+
+  @override
+  Stream<InfoWindowTapEvent> onInfoWindowTap({required int mapId}) {
+    return const Stream<InfoWindowTapEvent>.empty();
+  }
+
+  @override
+  Stream<PolylineTapEvent> onPolylineTap({required int mapId}) {
+    return const Stream<PolylineTapEvent>.empty();
+  }
+
+  @override
+  Stream<PolygonTapEvent> onPolygonTap({required int mapId}) {
+    return const Stream<PolygonTapEvent>.empty();
+  }
+
+  @override
+  Stream<CircleTapEvent> onCircleTap({required int mapId}) {
+    return const Stream<CircleTapEvent>.empty();
+  }
+
+  @override
+  Stream<MapTapEvent> onTap({required int mapId}) {
+    return const Stream<MapTapEvent>.empty();
+  }
+
+  @override
+  Stream<MapLongPressEvent> onLongPress({required int mapId}) {
+    return const Stream<MapLongPressEvent>.empty();
+  }
+
+  @override
+  void dispose({required int mapId}) {}
+
+  @override
+  void enableDebugInspection() {}
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  late _FakeGoogleMapsFlutterPlatform fakePlatform;
+
+  setUp(() {
+    fakePlatform = _FakeGoogleMapsFlutterPlatform();
+    GoogleMapsFlutterPlatform.instance = fakePlatform;
+  });
+
+  testWidgets('renders GoogleMap with maximum zoom', (tester) async {
+    const initialCameraPosition = CameraPosition(
+      target: LatLng(10, 10),
+      zoom: 21,
+    );
+
+    await tester.pumpWidget(
+      const MaterialApp(
+        home: CitizenMapScreen(
+          initialCameraPosition: initialCameraPosition,
+        ),
+      ),
+    );
+
+    await tester.pump();
+
+    expect(find.byType(GoogleMap), findsOneWidget);
+    expect(fakePlatform.lastCameraPosition, isNotNull);
+    expect(fakePlatform.lastCameraPosition!.zoom, equals(21));
+  });
+}

--- a/web/index.html
+++ b/web/index.html
@@ -29,6 +29,7 @@
 
   <title>citizen_reports_flutter</title>
   <link rel="manifest" href="manifest.json">
+  <script async defer src="https://maps.googleapis.com/maps/api/js?key=YOUR_WEB_GOOGLE_MAPS_API_KEY"></script>
 </head>
 <body>
   <script src="flutter_bootstrap.js" async></script>


### PR DESCRIPTION
## Summary
- add the google_maps_flutter dependency and configure Android, iOS, and web API key wiring
- replace the placeholder citizen map screen with an interactive GoogleMap that exposes selection callbacks
- add a widget test with a fake Google Maps platform interface to verify the map initializes at maximum zoom

## Testing
- flutter test *(fails: flutter executable not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68e5b9ddac5083299113e2d0cfcd8395