### PR TITLE
Implement responsive admin navigation with new destinations

### DIFF
--- a/lib/src/presentation/admin/admin_shell.dart
+++ b/lib/src/presentation/admin/admin_shell.dart
@@ -3,12 +3,17 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../../app/providers.dart';
 import 'dashboard/admin_dashboard_screen.dart';
+import 'private_map/admin_private_map_screen.dart';
+import 'profile/admin_profile_screen.dart';
 import 'reports/report_detail_screen.dart';
 import 'reports/report_list_screen.dart';
+import 'settings/admin_settings_screen.dart';
 import 'state/admin_navigation_controller.dart';
 
 class AdminShell extends ConsumerWidget {
-  const AdminShell({super.key});
+  const AdminShell({super.key, this.privateMapBuilder});
+
+  final WidgetBuilder? privateMapBuilder;
 
   static final _navigatorKey = GlobalKey<NavigatorState>(
     //1.- Conservamos una única referencia para mantener el historial interno.
@@ -17,80 +22,261 @@ class AdminShell extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    //1.- Observamos el estado de navegación para determinar las rutas activas.
+    //1.- Observamos el estado de navegación para determinar la ruta activa.
     final navigation = ref.watch(adminNavigationProvider);
     final navigatorController = ref.read(adminNavigationProvider.notifier);
-    //2.- Renderizamos la estructura base con navegación anidada para el panel administrativo.
-    return Scaffold(
-      appBar: AppBar(title: const Text('Panel administrativo')),
-      drawer: Drawer(
-        child: Column(
-          children: [
-            const DrawerHeader(child: Text('Citizen Reports')),
-            ListTile(
-              leading: const Icon(Icons.list_alt),
-              title: const Text('Dashboard'),
-              selected: navigation.route == AdminRoute.dashboard,
-              onTap: () {
-                //1.- Cerramos el menú lateral y navegamos a la pantalla principal.
-                Navigator.of(context).pop();
-                navigatorController.goToDashboard();
-              },
+    final mapBuilder = privateMapBuilder ?? AdminPrivateMapScreen.buildDefaultMap;
+    final destinations = _AdminDestination.values;
+    final selectedRoute = _AdminDestination.baseRouteFor(navigation.route);
+    final selectedIndex = destinations.indexWhere(
+      (destination) => destination.route == selectedRoute,
+    );
+
+    void handleDestinationSelection(int index) {
+      //1.- Redirigimos el flujo según el destino elegido en el menú adaptable.
+      final destination = destinations[index];
+      switch (destination.route) {
+        case AdminRoute.privateMap:
+          navigatorController.goToPrivateMap();
+          break;
+        case AdminRoute.dashboard:
+          navigatorController.goToDashboard();
+          break;
+        case AdminRoute.reports:
+          navigatorController.goToReports();
+          break;
+        case AdminRoute.settings:
+          navigatorController.goToSettings();
+          break;
+        case AdminRoute.profile:
+          navigatorController.goToProfile();
+          break;
+        case AdminRoute.reportDetail:
+          break;
+      }
+    }
+
+    final navigatorWidget = _AdminNavigator(
+      navigation: navigation,
+      controller: navigatorController,
+      navigatorKey: _navigatorKey,
+      mapBuilder: mapBuilder,
+    );
+
+    return LayoutBuilder(
+      builder: (context, constraints) {
+        //1.- Adaptamos el contenedor según el ancho disponible para mejorar la usabilidad.
+        final useRail = constraints.maxWidth >= 900;
+        final safeSelectedIndex = selectedIndex >= 0 ? selectedIndex : 1;
+
+        if (useRail) {
+          return Scaffold(
+            appBar: AppBar(
+              title: const Text('Panel administrativo'),
+              actions: [
+                IconButton(
+                  icon: const Icon(Icons.logout),
+                  onPressed: () {
+                    //1.- Cerramos la sesión actual sin abandonar la sección en pantalla.
+                    ref.read(sessionControllerProvider.notifier).signOut();
+                  },
+                  tooltip: 'Cerrar sesión',
+                ),
+              ],
             ),
-            ListTile(
-              leading: const Icon(Icons.assignment),
-              title: const Text('Reportes'),
-              selected: navigation.route == AdminRoute.reportList ||
-                  navigation.route == AdminRoute.reportDetail,
-              onTap: () {
-                //1.- Cerramos el menú lateral y navegamos al listado de reportes.
-                Navigator.of(context).pop();
-                navigatorController.goToReportList();
-              },
+            body: Row(
+              children: [
+                NavigationRail(
+                  selectedIndex: safeSelectedIndex,
+                  onDestinationSelected: handleDestinationSelection,
+                  extended: constraints.maxWidth >= 1200,
+                  destinations: [
+                    for (final destination in destinations)
+                      NavigationRailDestination(
+                        icon: Icon(destination.icon),
+                        label: Text(destination.label),
+                      ),
+                  ],
+                ),
+                const VerticalDivider(width: 1),
+                Expanded(child: navigatorWidget),
+              ],
             ),
-            const Spacer(),
-            ListTile(
-              leading: const Icon(Icons.logout),
-              title: const Text('Cerrar sesión'),
-              onTap: () {
-                //1.- Notificamos al controlador de sesión para invalidar el token.
-                ref.read(sessionControllerProvider.notifier).signOut();
-              },
-            ),
-          ],
-        ),
-      ),
-      body: Navigator(
-        key: _navigatorKey,
-        //1.- Construimos la pila de páginas en función del estado del controlador.
-        pages: [
-          const MaterialPage(
-            key: ValueKey('admin-dashboard-page'),
-            child: AdminDashboardScreen(),
-          ),
-          if (navigation.route == AdminRoute.reportList ||
-              navigation.route == AdminRoute.reportDetail)
-            MaterialPage(
-              key: const ValueKey('admin-report-list-page'),
-              child: ReportListScreen(
-                onReportSelected: navigatorController.openReportDetail,
+          );
+        }
+
+        return Scaffold(
+          appBar: AppBar(
+            title: const Text('Panel administrativo'),
+            actions: [
+              IconButton(
+                icon: const Icon(Icons.logout),
+                onPressed: () {
+                  //1.- Habilitamos el cierre de sesión desde dispositivos compactos.
+                  ref.read(sessionControllerProvider.notifier).signOut();
+                },
+                tooltip: 'Cerrar sesión',
               ),
+            ],
+          ),
+          body: navigatorWidget,
+          bottomNavigationBar: NavigationBar(
+            selectedIndex: safeSelectedIndex,
+            onDestinationSelected: handleDestinationSelection,
+            destinations: [
+              for (final destination in destinations)
+                NavigationDestination(
+                  icon: Icon(destination.icon),
+                  label: destination.label,
+                ),
+            ],
+          ),
+        );
+      },
+    );
+  }
+}
+
+class _AdminNavigator extends StatelessWidget {
+  const _AdminNavigator({
+    required this.navigation,
+    required this.controller,
+    required this.navigatorKey,
+    required this.mapBuilder,
+  });
+
+  final AdminNavigationState navigation;
+  final AdminNavigationController controller;
+  final GlobalKey<NavigatorState> navigatorKey;
+  final WidgetBuilder mapBuilder;
+
+  @override
+  Widget build(BuildContext context) {
+    //1.- Construimos la pila de navegación interna respetando el flujo seleccionado.
+    final pages = <Page<void>>[
+      const MaterialPage(
+        key: ValueKey('admin-dashboard-page'),
+        child: AdminDashboardScreen(),
+      ),
+    ];
+
+    switch (navigation.route) {
+      case AdminRoute.dashboard:
+        break;
+      case AdminRoute.reports:
+        pages.add(
+          MaterialPage(
+            key: const ValueKey('admin-report-list-page'),
+            child: ReportListScreen(
+              onReportSelected: controller.openReportDetail,
             ),
-          if (navigation.route == AdminRoute.reportDetail &&
-              navigation.selectedReportId != null)
+          ),
+        );
+        break;
+      case AdminRoute.reportDetail:
+        pages.add(
+          MaterialPage(
+            key: const ValueKey('admin-report-list-page'),
+            child: ReportListScreen(
+              onReportSelected: controller.openReportDetail,
+            ),
+          ),
+        );
+        if (navigation.selectedReportId != null) {
+          pages.add(
             MaterialPage(
               key: ValueKey('admin-report-detail-${navigation.selectedReportId}'),
-              child: ReportDetailScreen(reportId: navigation.selectedReportId!),
+              child: ReportDetailScreen(
+                reportId: navigation.selectedReportId!,
+              ),
             ),
-        ],
-        onPopPage: (route, result) {
-          //1.- Intentamos cerrar la ruta actual y sincronizamos el estado global.
-          if (!route.didPop(result)) {
-            return false;
-          }
-          return navigatorController.handlePop();
-        },
-      ),
+          );
+        }
+        break;
+      case AdminRoute.privateMap:
+        pages.add(
+          MaterialPage(
+            key: const ValueKey('admin-private-map-page'),
+            child: AdminPrivateMapScreen(mapBuilder: mapBuilder),
+          ),
+        );
+        break;
+      case AdminRoute.settings:
+        pages.add(
+          const MaterialPage(
+            key: ValueKey('admin-settings-page'),
+            child: AdminSettingsScreen(),
+          ),
+        );
+        break;
+      case AdminRoute.profile:
+        pages.add(
+          const MaterialPage(
+            key: ValueKey('admin-profile-page'),
+            child: AdminProfileScreen(),
+          ),
+        );
+        break;
+    }
+
+    return Navigator(
+      key: navigatorKey,
+      pages: pages,
+      onPopPage: (route, result) {
+        //1.- Sincronizamos el estado global cuando se solicita regresar en la pila interna.
+        if (!route.didPop(result)) {
+          return false;
+        }
+        return controller.handlePop();
+      },
     );
+  }
+}
+
+class _AdminDestination {
+  const _AdminDestination({
+    required this.route,
+    required this.icon,
+    required this.label,
+  });
+
+  final AdminRoute route;
+  final IconData icon;
+  final String label;
+
+  static List<_AdminDestination> get values => const [
+        _AdminDestination(
+          route: AdminRoute.privateMap,
+          icon: Icons.map_outlined,
+          label: 'Mapa privado',
+        ),
+        _AdminDestination(
+          route: AdminRoute.dashboard,
+          icon: Icons.dashboard_outlined,
+          label: 'Tablero',
+        ),
+        _AdminDestination(
+          route: AdminRoute.reports,
+          icon: Icons.assignment_outlined,
+          label: 'Reportes',
+        ),
+        _AdminDestination(
+          route: AdminRoute.settings,
+          icon: Icons.settings_outlined,
+          label: 'Configuración',
+        ),
+        _AdminDestination(
+          route: AdminRoute.profile,
+          icon: Icons.person_outline,
+          label: 'Perfil',
+        ),
+      ];
+
+  static AdminRoute baseRouteFor(AdminRoute route) {
+    //1.- Normalizamos rutas secundarias para mantener la selección en la navegación.
+    if (route == AdminRoute.reportDetail) {
+      return AdminRoute.reports;
+    }
+    return route;
   }
 }

--- a/lib/src/presentation/admin/dashboard/admin_dashboard_screen.dart
+++ b/lib/src/presentation/admin/dashboard/admin_dashboard_screen.dart
@@ -76,7 +76,7 @@ class AdminDashboardScreen extends ConsumerWidget {
             label: 'Ver listado completo',
             onPressed: () {
               //1.- Navegamos al listado de reportes usando el controlador global.
-              navigator.goToReportList();
+              navigator.goToReports();
             },
           ),
         ],

--- a/lib/src/presentation/admin/private_map/admin_private_map_screen.dart
+++ b/lib/src/presentation/admin/private_map/admin_private_map_screen.dart
@@ -1,0 +1,63 @@
+import 'package:flutter/material.dart';
+import 'package:google_maps_flutter/google_maps_flutter.dart';
+
+class AdminPrivateMapScreen extends StatelessWidget {
+  const AdminPrivateMapScreen({
+    super.key,
+    WidgetBuilder? mapBuilder,
+  }) : _mapBuilder = mapBuilder ?? AdminPrivateMapScreen.buildDefaultMap;
+
+  final WidgetBuilder _mapBuilder;
+
+  static Widget buildDefaultMap(BuildContext context) {
+    //1.- Configuramos el mapa con un enfoque inicial en el centro de la ciudad.
+    return const GoogleMap(
+      initialCameraPosition: CameraPosition(
+        target: LatLng(19.4326, -99.1332),
+        zoom: 12,
+      ),
+      zoomControlsEnabled: false,
+      myLocationButtonEnabled: false,
+      compassEnabled: true,
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    //1.- Organizamos la interfaz con encabezado descriptivo y mapa interactivo.
+    return SafeArea(
+      child: Padding(
+        padding: const EdgeInsets.all(24),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Text(
+              'Mapa privado de incidencias',
+              style: Theme.of(context).textTheme.headlineSmall,
+            ),
+            const SizedBox(height: 12),
+            Text(
+              'Visualiza la distribución geográfica de los reportes en tiempo real.',
+              style: Theme.of(context).textTheme.bodyMedium,
+            ),
+            const SizedBox(height: 24),
+            Expanded(
+              child: ClipRRect(
+                borderRadius: BorderRadius.circular(24),
+                child: DecoratedBox(
+                  decoration: BoxDecoration(
+                    border: Border.all(
+                      color: Theme.of(context).colorScheme.outlineVariant,
+                    ),
+                    borderRadius: BorderRadius.circular(24),
+                  ),
+                  child: _mapBuilder(context),
+                ),
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/src/presentation/admin/profile/admin_profile_screen.dart
+++ b/lib/src/presentation/admin/profile/admin_profile_screen.dart
@@ -1,0 +1,87 @@
+import 'package:flutter/material.dart';
+
+class AdminProfileScreen extends StatelessWidget {
+  const AdminProfileScreen({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    //1.- Presentamos la información clave del perfil administrativo con acciones rápidas.
+    return SafeArea(
+      child: Padding(
+        padding: const EdgeInsets.all(24),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Row(
+              children: [
+                CircleAvatar(
+                  radius: 32,
+                  backgroundColor: Theme.of(context).colorScheme.primaryContainer,
+                  child: const Icon(Icons.person, size: 32),
+                ),
+                const SizedBox(width: 16),
+                Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Text(
+                      'Mariana López',
+                      style: Theme.of(context).textTheme.headlineSmall,
+                    ),
+                    Text(
+                      'Administradora general',
+                      style: Theme.of(context).textTheme.bodyMedium,
+                    ),
+                  ],
+                ),
+              ],
+            ),
+            const SizedBox(height: 24),
+            Text(
+              'Contacto',
+              style: Theme.of(context).textTheme.titleMedium,
+            ),
+            const SizedBox(height: 8),
+            ListTile(
+              leading: const Icon(Icons.email_outlined),
+              title: const Text('mariana.lopez@ciudad.gob'),
+              subtitle: const Text('Correo institucional'),
+            ),
+            ListTile(
+              leading: const Icon(Icons.call_outlined),
+              title: const Text('+52 55 1234 5678'),
+              subtitle: const Text('Teléfono de guardia'),
+            ),
+            const Divider(height: 32),
+            Text(
+              'Roles y permisos',
+              style: Theme.of(context).textTheme.titleMedium,
+            ),
+            const SizedBox(height: 8),
+            Chip(
+              label: const Text('Gestión de reportes'),
+              backgroundColor: Theme.of(context).colorScheme.surfaceVariant,
+            ),
+            const SizedBox(height: 8),
+            Chip(
+              label: const Text('Configuración avanzada'),
+              backgroundColor: Theme.of(context).colorScheme.surfaceVariant,
+            ),
+            const Spacer(),
+            FilledButton.icon(
+              onPressed: () {
+                //1.- Simulamos el envío de una solicitud para actualizar los datos del perfil.
+                ScaffoldMessenger.of(context).showSnackBar(
+                  const SnackBar(
+                    content: Text('Se solicitó la actualización del perfil.'),
+                  ),
+                );
+              },
+              icon: const Icon(Icons.edit_outlined),
+              label: const Text('Actualizar perfil'),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/src/presentation/admin/reports/report_detail_screen.dart
+++ b/lib/src/presentation/admin/reports/report_detail_screen.dart
@@ -163,7 +163,7 @@ class _ReportDetailScreenState extends ConsumerState<ReportDetailScreen> {
                                     );
                                     ref
                                         .read(adminNavigationProvider.notifier)
-                                        .goToReportList();
+                                        .goToReports();
                                   } catch (error) {
                                     if (!mounted) return;
                                     ScaffoldMessenger.of(context).showSnackBar(

--- a/lib/src/presentation/admin/settings/admin_settings_screen.dart
+++ b/lib/src/presentation/admin/settings/admin_settings_screen.dart
@@ -1,0 +1,88 @@
+import 'package:flutter/material.dart';
+
+class AdminSettingsScreen extends StatefulWidget {
+  const AdminSettingsScreen({super.key});
+
+  @override
+  State<AdminSettingsScreen> createState() => _AdminSettingsScreenState();
+}
+
+class _AdminSettingsScreenState extends State<AdminSettingsScreen> {
+  bool _notificationsEnabled = true;
+  bool _autoAssignIncidents = false;
+  TimeOfDay _digestTime = const TimeOfDay(hour: 8, minute: 0);
+
+  Future<void> _selectDigestTime(BuildContext context) async {
+    //1.- Abrimos el selector nativo para elegir la hora de envío del resumen diario.
+    final selected = await showTimePicker(
+      context: context,
+      initialTime: _digestTime,
+    );
+    if (selected != null) {
+      setState(() {
+        //2.- Persistimos la nueva configuración localmente dentro del estado temporal.
+        _digestTime = selected;
+      });
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    //1.- Componemos un formulario sencillo que simula preferencias administrativas.
+    return SafeArea(
+      child: ListView(
+        padding: const EdgeInsets.all(24),
+        children: [
+          Text(
+            'Configuración del panel',
+            style: Theme.of(context).textTheme.headlineSmall,
+          ),
+          const SizedBox(height: 16),
+          SwitchListTile.adaptive(
+            value: _notificationsEnabled,
+            onChanged: (value) {
+              //1.- Alternamos la recepción de notificaciones críticas para el panel.
+              setState(() => _notificationsEnabled = value);
+            },
+            title: const Text('Notificaciones críticas'),
+            subtitle: const Text(
+              'Recibe alertas en tiempo real cuando se detecten incidencias críticas.',
+            ),
+          ),
+          const Divider(),
+          SwitchListTile.adaptive(
+            value: _autoAssignIncidents,
+            onChanged: (value) {
+              //1.- Controlamos si el sistema asigna automáticamente reportes a agentes.
+              setState(() => _autoAssignIncidents = value);
+            },
+            title: const Text('Asignación automática'),
+            subtitle: const Text(
+              'Distribuye incidentes entrantes entre los equipos disponibles.',
+            ),
+          ),
+          const Divider(),
+          ListTile(
+            leading: const Icon(Icons.schedule),
+            title: const Text('Hora del resumen diario'),
+            subtitle: Text('Programado a las ${_digestTime.format(context)}'),
+            onTap: () => _selectDigestTime(context),
+          ),
+          const SizedBox(height: 32),
+          FilledButton.icon(
+            onPressed: () {
+              //1.- Simulamos un guardado local para mostrar retroalimentación inmediata.
+              ScaffoldMessenger.of(context).showSnackBar(
+                const SnackBar(
+                  content: Text('Preferencias guardadas correctamente.'),
+                ),
+              );
+            },
+            icon: const Icon(Icons.save),
+            label: const Text('Guardar cambios'),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/src/presentation/admin/state/admin_navigation_controller.dart
+++ b/lib/src/presentation/admin/state/admin_navigation_controller.dart
@@ -1,6 +1,13 @@
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
-enum AdminRoute { dashboard, reportList, reportDetail }
+enum AdminRoute {
+  dashboard,
+  reports,
+  reportDetail,
+  privateMap,
+  settings,
+  profile,
+}
 
 class AdminNavigationState {
   const AdminNavigationState({
@@ -30,9 +37,24 @@ class AdminNavigationController extends StateNotifier<AdminNavigationState> {
     state = const AdminNavigationState(route: AdminRoute.dashboard);
   }
 
-  void goToReportList() {
+  void goToReports() {
     //1.- Mostramos la tabla con el historial completo de reportes.
-    state = const AdminNavigationState(route: AdminRoute.reportList);
+    state = const AdminNavigationState(route: AdminRoute.reports);
+  }
+
+  void goToPrivateMap() {
+    //1.- Cargamos el mapa privado para visualizar la distribución geográfica.
+    state = const AdminNavigationState(route: AdminRoute.privateMap);
+  }
+
+  void goToSettings() {
+    //1.- Abrimos el módulo de configuración del panel administrativo.
+    state = const AdminNavigationState(route: AdminRoute.settings);
+  }
+
+  void goToProfile() {
+    //1.- Permitimos que la persona administradora revise y edite su perfil.
+    state = const AdminNavigationState(route: AdminRoute.profile);
   }
 
   void openReportDetail(String reportId) {
@@ -46,10 +68,16 @@ class AdminNavigationController extends StateNotifier<AdminNavigationState> {
   bool handlePop() {
     //1.- Interceptamos la navegación hacia atrás para movernos entre pantallas anidadas.
     if (state.route == AdminRoute.reportDetail) {
-      goToReportList();
+      goToReports();
       return true;
     }
-    if (state.route == AdminRoute.reportList) {
+    if (state.route == AdminRoute.reports) {
+      goToDashboard();
+      return true;
+    }
+    if (state.route == AdminRoute.privateMap ||
+        state.route == AdminRoute.settings ||
+        state.route == AdminRoute.profile) {
       goToDashboard();
       return true;
     }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -37,6 +37,7 @@ dependencies:
   flutter_riverpod: ^2.5.1
   dio: ^5.7.0
   equatable: ^2.0.5
+  google_maps_flutter: ^2.7.0
 
 dev_dependencies:
   flutter_test:

--- a/test/presentation/admin/admin_dashboard_screen_test.dart
+++ b/test/presentation/admin/admin_dashboard_screen_test.dart
@@ -87,7 +87,7 @@ void main() {
 
     expect(
       container.read(adminNavigationProvider).route,
-      AdminRoute.reportList,
+      AdminRoute.reports,
     );
   });
 }

--- a/test/presentation/admin/admin_shell_navigation_test.dart
+++ b/test/presentation/admin/admin_shell_navigation_test.dart
@@ -1,0 +1,176 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:citizen_reports_flutter/src/app/providers.dart';
+import 'package:citizen_reports_flutter/src/domain/entities/admin_dashboard_metrics.dart';
+import 'package:citizen_reports_flutter/src/domain/entities/folio_status.dart';
+import 'package:citizen_reports_flutter/src/domain/entities/incident_type.dart';
+import 'package:citizen_reports_flutter/src/domain/entities/paginated_reports.dart';
+import 'package:citizen_reports_flutter/src/domain/entities/report.dart';
+import 'package:citizen_reports_flutter/src/domain/repositories/reports_repository.dart';
+import 'package:citizen_reports_flutter/src/presentation/admin/admin_shell.dart';
+import 'package:citizen_reports_flutter/src/presentation/admin/state/admin_navigation_controller.dart';
+
+class _ShellReportsRepository implements ReportsRepository {
+  const _ShellReportsRepository();
+
+  Report get _sampleReport => Report(
+        id: 'TEST-1',
+        incidentType: const IncidentType(
+          id: 'fire',
+          name: 'Incendio',
+          requiresEvidence: true,
+        ),
+        description: 'Simulación de incidente',
+        latitude: 19.4,
+        longitude: -99.1,
+        status: 'en_revision',
+        createdAt: DateTime(2024, 1, 1, 8),
+      );
+
+  @override
+  Future<AdminDashboardMetrics> fetchDashboardMetrics() async {
+    //1.- Entregamos métricas determinísticas para estabilizar las pruebas.
+    return const AdminDashboardMetrics(
+      pendingReports: 1,
+      resolvedReports: 5,
+      criticalIncidents: 0,
+    );
+  }
+
+  @override
+  Future<PaginatedReports> fetchReports({
+    required int page,
+    required int pageSize,
+  }) async {
+    //1.- Simulamos una respuesta paginada con un único reporte de ejemplo.
+    return PaginatedReports(
+      items: [_sampleReport],
+      hasMore: false,
+      page: page,
+    );
+  }
+
+  @override
+  Future<Report> fetchReportById(String id) async {
+    //1.- Reutilizamos el mismo reporte para simplificar el escenario de prueba.
+    return _sampleReport;
+  }
+
+  @override
+  Future<Report> updateReportStatus({
+    required String id,
+    required String status,
+  }) {
+    throw UnimplementedError();
+  }
+
+  @override
+  Future<void> deleteReport(String id) {
+    throw UnimplementedError();
+  }
+
+  @override
+  Future<Report> submitReport(ReportRequest request) {
+    throw UnimplementedError();
+  }
+
+  @override
+  Future<FolioStatus> lookupFolio(String folio) {
+    throw UnimplementedError();
+  }
+}
+
+WidgetBuilder get _stubMapBuilder => (_) => const Placeholder(key: ValueKey('stub-map'));
+
+void main() {
+  testWidgets('muestra NavigationRail en pantallas amplias', (tester) async {
+    //1.- Renderizamos el shell con un ancho suficiente para habilitar la barra lateral.
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: const [
+          reportsRepositoryProvider.overrideWithValue(_ShellReportsRepository()),
+        ],
+        child: MediaQuery(
+          data: const MediaQueryData(size: Size(1200, 800)),
+          child: MaterialApp(
+            home: AdminShell(privateMapBuilder: _stubMapBuilder),
+          ),
+        ),
+      ),
+    );
+
+    await tester.pumpAndSettle();
+
+    expect(find.byType(NavigationRail), findsOneWidget);
+    expect(find.byType(NavigationBar), findsNothing);
+  });
+
+  testWidgets('muestra NavigationBar en pantallas compactas', (tester) async {
+    //1.- Reducimos el ancho disponible para activar la navegación inferior.
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: const [
+          reportsRepositoryProvider.overrideWithValue(_ShellReportsRepository()),
+        ],
+        child: MediaQuery(
+          data: const MediaQueryData(size: Size(400, 800)),
+          child: MaterialApp(
+            home: AdminShell(privateMapBuilder: _stubMapBuilder),
+          ),
+        ),
+      ),
+    );
+
+    await tester.pumpAndSettle();
+
+    expect(find.byType(NavigationRail), findsNothing);
+    expect(find.byType(NavigationBar), findsOneWidget);
+  });
+
+  testWidgets('permite navegar a cada destino principal', (tester) async {
+    //1.- Preparamos el entorno con repositorio simulado para alimentar las pantallas.
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: const [
+          reportsRepositoryProvider.overrideWithValue(_ShellReportsRepository()),
+        ],
+        child: MediaQuery(
+          data: const MediaQueryData(size: Size(1200, 800)),
+          child: MaterialApp(
+            home: AdminShell(privateMapBuilder: _stubMapBuilder),
+          ),
+        ),
+      ),
+    );
+
+    await tester.pumpAndSettle();
+
+    //2.- Abrimos el mapa privado y verificamos la presencia del encabezado.
+    await tester.tap(find.byIcon(Icons.map_outlined).first);
+    await tester.pumpAndSettle();
+    expect(find.text('Mapa privado de incidencias'), findsOneWidget);
+
+    //3.- Navegamos al listado de reportes y comprobamos que el folio se muestre.
+    await tester.tap(find.byIcon(Icons.assignment_outlined).first);
+    await tester.pumpAndSettle();
+    expect(find.text('Folio TEST-1'), findsOneWidget);
+
+    //4.- Movemos la navegación hacia la sección de configuración.
+    await tester.tap(find.byIcon(Icons.settings_outlined).first);
+    await tester.pumpAndSettle();
+    expect(find.text('Configuración del panel'), findsOneWidget);
+
+    //5.- Seleccionamos la vista de perfil para verificar su encabezado principal.
+    await tester.tap(find.byIcon(Icons.person_outline).first);
+    await tester.pumpAndSettle();
+    expect(find.text('Mariana López'), findsOneWidget);
+
+    //6.- Confirmamos que el estado global refleja la última selección realizada.
+    final container = ProviderScope.containerOf(
+      tester.element(find.byType(AdminShell)),
+    );
+    expect(container.read(adminNavigationProvider).route, AdminRoute.profile);
+  });
+}


### PR DESCRIPTION
## Summary
- add the Google Maps dependency and extend the admin navigation controller with new routes
- replace the drawer-based shell with a responsive rail/navigation bar and load the new admin pages
- create private map, settings, and profile screens plus widget coverage for responsive navigation

## Testing
- flutter test *(fails: Flutter SDK is not available in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e5bd4fe27483299a65fc2ce4065851