### PR TITLE
Add OpenAPI specification for Citizen Reports API

### DIFF
--- a/backend/go/api/openapi.yaml
+++ b/backend/go/api/openapi.yaml
@@ -1,0 +1,538 @@
+openapi: 3.0.3
+info:
+  title: Citizen Reports API
+  version: 0.1.0
+  description: |
+    REST API for the Citizen Reports mobile application. The service supports citizen
+    report submissions, folio tracking, catalog discovery, and administrative dashboards.
+servers:
+  - url: https://api.citizenreports.local
+    description: Production (example)
+  - url: http://localhost:8080
+    description: Local development
+tags:
+  - name: Auth
+    description: Session management for citizens and administrators.
+  - name: Catalog
+    description: Incident catalog lookups used to populate report forms.
+  - name: Reports
+    description: Citizen submissions and administrative report management.
+  - name: Folios
+    description: Folio tracking for existing incident reports.
+  - name: Admin
+    description: Administrative dashboards and aggregates.
+paths:
+  /api/v1/auth/login:
+    post:
+      tags: [Auth]
+      summary: Authenticate with email and password
+      operationId: loginWithEmail
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/AuthCredentials'
+      responses:
+        '200':
+          description: Authentication succeeded
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AuthToken'
+        '400':
+          description: Invalid request payload
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '401':
+          description: Authentication failed
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+  /api/v1/auth/register:
+    post:
+      tags: [Auth]
+      summary: Register a new user account
+      operationId: registerUser
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/AuthCredentials'
+      responses:
+        '201':
+          description: Registration succeeded
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AuthToken'
+        '400':
+          description: Invalid registration payload
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '409':
+          description: Email already registered
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+  /api/v1/auth/recover:
+    post:
+      tags: [Auth]
+      summary: Send a password recovery email
+      operationId: recoverPassword
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [email]
+              properties:
+                email:
+                  type: string
+                  format: email
+                  description: Account email that will receive recovery instructions.
+      responses:
+        '202':
+          description: Recovery email enqueued
+        '400':
+          description: Invalid email supplied
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+  /api/v1/auth/social/{provider}:
+    post:
+      tags: [Auth]
+      summary: Sign in using a federated provider
+      operationId: loginWithSocialProvider
+      parameters:
+        - in: path
+          name: provider
+          required: true
+          description: Social identity provider identifier.
+          schema:
+            type: string
+            enum: [google, apple, facebook]
+      responses:
+        '200':
+          description: Social authentication succeeded
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AuthToken'
+        '400':
+          description: Unsupported provider or invalid state
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+  /api/v1/catalog/incident-types:
+    get:
+      tags: [Catalog]
+      summary: Retrieve available incident types
+      operationId: getIncidentTypes
+      responses:
+        '200':
+          description: List of incident types
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/IncidentType'
+        '503':
+          description: Catalog temporarily unavailable
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+  /api/v1/reports:
+    get:
+      tags: [Reports]
+      summary: List reports for administrative review
+      operationId: listReports
+      security:
+        - bearerAuth: []
+      parameters:
+        - in: query
+          name: page
+          schema:
+            type: integer
+            minimum: 0
+            default: 0
+          description: Zero-based page index.
+        - in: query
+          name: pageSize
+          schema:
+            type: integer
+            minimum: 1
+            maximum: 100
+            default: 20
+          description: Number of items per page.
+        - in: query
+          name: status
+          schema:
+            type: string
+            enum: [en_revision, en_proceso, resuelto, critico]
+          description: Optional filter by report status.
+      responses:
+        '200':
+          description: Paginated reports
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PaginatedReports'
+        '401':
+          description: Missing or invalid credentials
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+    post:
+      tags: [Reports]
+      summary: Submit a new citizen report
+      operationId: submitReport
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ReportSubmission'
+      responses:
+        '201':
+          description: Report created successfully
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Report'
+        '400':
+          description: Invalid report submission payload
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+  /api/v1/reports/{id}:
+    get:
+      tags: [Reports]
+      summary: Retrieve report details by identifier
+      operationId: getReport
+      security:
+        - bearerAuth: []
+      parameters:
+        - in: path
+          name: id
+          required: true
+          schema:
+            type: string
+          description: Report folio identifier.
+      responses:
+        '200':
+          description: Report detail
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Report'
+        '401':
+          description: Missing or invalid credentials
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '404':
+          description: Report not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+    patch:
+      tags: [Reports]
+      summary: Update the status of a report
+      operationId: updateReportStatus
+      security:
+        - bearerAuth: []
+      parameters:
+        - in: path
+          name: id
+          required: true
+          schema:
+            type: string
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [status]
+              properties:
+                status:
+                  type: string
+                  description: New workflow status for the report.
+                  enum: [en_revision, en_proceso, resuelto, critico]
+      responses:
+        '200':
+          description: Updated report snapshot
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Report'
+        '400':
+          description: Invalid status transition
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '401':
+          description: Missing or invalid credentials
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '404':
+          description: Report not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+    delete:
+      tags: [Reports]
+      summary: Delete a report
+      operationId: deleteReport
+      security:
+        - bearerAuth: []
+      parameters:
+        - in: path
+          name: id
+          required: true
+          schema:
+            type: string
+      responses:
+        '204':
+          description: Report deleted successfully
+        '401':
+          description: Missing or invalid credentials
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '404':
+          description: Report not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+  /api/v1/folios/{folio}:
+    get:
+      tags: [Folios]
+      summary: Retrieve the current status of a folio
+      operationId: getFolioStatus
+      parameters:
+        - in: path
+          name: folio
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Folio status details
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/FolioStatus'
+        '404':
+          description: Folio not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+  /api/v1/admin/dashboard/metrics:
+    get:
+      tags: [Admin]
+      summary: Retrieve dashboard metrics
+      operationId: getDashboardMetrics
+      security:
+        - bearerAuth: []
+      responses:
+        '200':
+          description: Aggregated dashboard metrics
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AdminDashboardMetrics'
+        '401':
+          description: Missing or invalid credentials
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+components:
+  securitySchemes:
+    bearerAuth:
+      type: http
+      scheme: bearer
+      bearerFormat: JWT
+  schemas:
+    AuthCredentials:
+      type: object
+      required: [email, password]
+      properties:
+        email:
+          type: string
+          format: email
+        password:
+          type: string
+          format: password
+          minLength: 8
+    AuthToken:
+      type: object
+      required: [token, expiresAt]
+      properties:
+        token:
+          type: string
+        expiresAt:
+          type: string
+          format: date-time
+    IncidentType:
+      type: object
+      required: [id, name, requiresEvidence]
+      properties:
+        id:
+          type: string
+        name:
+          type: string
+        requiresEvidence:
+          type: boolean
+    ReportSubmission:
+      type: object
+      required:
+        - incidentTypeId
+        - description
+        - contactEmail
+        - contactPhone
+        - latitude
+        - longitude
+        - address
+      properties:
+        incidentTypeId:
+          type: string
+        description:
+          type: string
+          maxLength: 2000
+        contactEmail:
+          type: string
+          format: email
+        contactPhone:
+          type: string
+          description: Digits only, 10 to 15 characters.
+          pattern: '^\\+?[0-9]{10,15}$'
+        latitude:
+          type: number
+          format: double
+          minimum: -90
+          maximum: 90
+        longitude:
+          type: number
+          format: double
+          minimum: -180
+          maximum: 180
+        address:
+          type: string
+          description: Human readable location reference.
+        evidenceUrls:
+          type: array
+          description: Optional supporting evidence URLs.
+          items:
+            type: string
+            format: uri
+    Report:
+      type: object
+      required:
+        - id
+        - incidentType
+        - description
+        - latitude
+        - longitude
+        - status
+        - createdAt
+      properties:
+        id:
+          type: string
+        incidentType:
+          $ref: '#/components/schemas/IncidentType'
+        description:
+          type: string
+        latitude:
+          type: number
+          format: double
+        longitude:
+          type: number
+          format: double
+        status:
+          type: string
+          enum: [en_revision, en_proceso, resuelto, critico]
+        createdAt:
+          type: string
+          format: date-time
+    PaginatedReports:
+      type: object
+      required: [items, hasMore, page]
+      properties:
+        items:
+          type: array
+          items:
+            $ref: '#/components/schemas/Report'
+        hasMore:
+          type: boolean
+        page:
+          type: integer
+          minimum: 0
+        totalCount:
+          type: integer
+          description: Optional total number of reports available.
+    FolioStatus:
+      type: object
+      required: [folio, status, lastUpdate, history]
+      properties:
+        folio:
+          type: string
+        status:
+          type: string
+          enum: [en_revision, en_proceso, resuelto, critico, no_encontrado]
+        lastUpdate:
+          type: string
+          format: date-time
+        history:
+          type: array
+          items:
+            type: string
+    AdminDashboardMetrics:
+      type: object
+      required: [pendingReports, resolvedReports, criticalIncidents]
+      properties:
+        pendingReports:
+          type: integer
+          minimum: 0
+        resolvedReports:
+          type: integer
+          minimum: 0
+        criticalIncidents:
+          type: integer
+          minimum: 0
+    ErrorResponse:
+      type: object
+      required: [code, message]
+      properties:
+        code:
+          type: integer
+        message:
+          type: string
+        details:
+          description: Optional machine-readable error context.
+          nullable: true


### PR DESCRIPTION
## Summary
- add an OpenAPI 3.0 specification documenting the planned Citizen Reports service
- describe authentication, catalog, reporting, folio, and admin dashboard endpoints consumed by the Flutter app
- include reusable schemas for tokens, reports, folios, pagination, and standardized errors

## Testing
- not run (documentation-only change)

------
https://chatgpt.com/codex/tasks/task_e_68e5c296d19c8329a63f7c29783c64cd