### PR TITLE
Add HTTP API tests and simplify router

### DIFF
--- a/backend/go/go.mod
+++ b/backend/go/go.mod
@@ -1,5 +1,3 @@
 module citizenapp/backend
 
 go 1.20
-
-require github.com/go-chi/chi/v5 v5.0.10

--- a/backend/go/go.sum
+++ b/backend/go/go.sum
@@ -1,2 +1,0 @@
-github.com/go-chi/chi/v5 v5.0.10 h1:rLz5avzKpjqxrYwXNfmjkrYYXOyLJd37pz53UFHC6vk=
-github.com/go-chi/chi/v5 v5.0.10/go.mod h1:DslCQbL2OYiznFReuXYUmQ2hGd1aDpCnlMNITLSKoi8=

--- a/backend/go/internal/http/server_test.go
+++ b/backend/go/internal/http/server_test.go
@@ -1,0 +1,104 @@
+package httpserver
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"citizenapp/backend/internal/service"
+)
+
+func TestRouterEndpoints(t *testing.T) {
+	// 1.- Construimos el servidor con servicios reales en memoria.
+	authSvc := service.NewAuthService(1, time.Minute)
+	catalogSvc := service.NewCatalogService(1)
+	reportSvc := service.NewReportService(1, 1)
+	srv := New(authSvc, catalogSvc, reportSvc)
+	handler := srv.Router()
+	ts := httptest.NewServer(handler)
+	defer ts.Close()
+
+	// 2.- Validamos el endpoint de autenticación.
+	authBody, _ := json.Marshal(map[string]string{"email": "user@demo.com", "password": "pass"})
+	resp, err := http.Post(ts.URL+"/auth", "application/json", bytes.NewReader(authBody))
+	if err != nil {
+		t.Fatalf("auth request failed: %v", err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("unexpected auth status: %d", resp.StatusCode)
+	}
+	_ = resp.Body.Close()
+
+	// 3.- Consultamos el catálogo asegurando la respuesta exitosa.
+	resp, err = http.Get(ts.URL + "/catalog")
+	if err != nil {
+		t.Fatalf("catalog request failed: %v", err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("unexpected catalog status: %d", resp.StatusCode)
+	}
+	_ = resp.Body.Close()
+
+	// 4.- Enviamos un reporte y revisamos el folio asignado.
+	reportBody, _ := json.Marshal(map[string]any{
+		"incidentTypeId": "pothole",
+		"description":    "Alcantarilla sin tapa",
+		"latitude":       19.4,
+		"longitude":      -99.1,
+	})
+	resp, err = http.Post(ts.URL+"/reports", "application/json", bytes.NewReader(reportBody))
+	if err != nil {
+		t.Fatalf("report request failed: %v", err)
+	}
+	if resp.StatusCode != http.StatusCreated {
+		t.Fatalf("unexpected report status: %d", resp.StatusCode)
+	}
+	var submitted service.Report
+	if err := json.NewDecoder(resp.Body).Decode(&submitted); err != nil {
+		t.Fatalf("cannot decode report: %v", err)
+	}
+	_ = resp.Body.Close()
+	if submitted.ID == "" {
+		t.Fatalf("expected folio in report response")
+	}
+
+	// 5.- Recuperamos el folio mediante el endpoint dedicado.
+	lookupResp, err := http.Get(ts.URL + "/folios/" + submitted.ID)
+	if err != nil {
+		t.Fatalf("lookup request failed: %v", err)
+	}
+	if lookupResp.StatusCode != http.StatusOK {
+		t.Fatalf("unexpected lookup status: %d", lookupResp.StatusCode)
+	}
+	var status service.FolioStatus
+	if err := json.NewDecoder(lookupResp.Body).Decode(&status); err != nil {
+		t.Fatalf("cannot decode lookup response: %v", err)
+	}
+	_ = lookupResp.Body.Close()
+	if status.Folio != submitted.ID {
+		t.Fatalf("folio mismatch: %s vs %s", status.Folio, submitted.ID)
+	}
+}
+
+func TestRouterTimeoutsPropagate(t *testing.T) {
+	// 1.- Creamos un contexto que vence inmediatamente para el servicio de autenticación.
+	authSvc := service.NewAuthService(1, time.Minute)
+	catalogSvc := service.NewCatalogService(1)
+	reportSvc := service.NewReportService(1, 1)
+	srv := New(authSvc, catalogSvc, reportSvc)
+
+	// 2.- Ejecutamos el handler con un contexto cancelado y verificamos el error.
+	req := httptest.NewRequest(http.MethodPost, "/auth", bytes.NewReader([]byte("{}")))
+	ctx, cancel := context.WithCancel(req.Context())
+	cancel()
+	req = req.WithContext(ctx)
+	rr := httptest.NewRecorder()
+	srv.handleAuth(rr, req)
+	if rr.Code != http.StatusBadRequest && rr.Code != http.StatusGatewayTimeout {
+		t.Fatalf("expected early termination status, got %d", rr.Code)
+	}
+}

--- a/backend/go/internal/service/auth_test.go
+++ b/backend/go/internal/service/auth_test.go
@@ -1,0 +1,48 @@
+package service
+
+import (
+	"context"
+	"crypto/sha1"
+	"encoding/hex"
+	"testing"
+	"time"
+)
+
+func TestAuthenticateGeneratesDeterministicToken(t *testing.T) {
+	// 1.- Preparamos el servicio con un TTL breve para validar el cálculo.
+	svc := NewAuthService(1, 2*time.Minute)
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+
+	// 2.- Ejecutamos la autenticación de un usuario controlado.
+	resp, err := svc.Authenticate(ctx, "user@example.com", "s3cr3t")
+	if err != nil {
+		t.Fatalf("Authenticate returned error: %v", err)
+	}
+
+	// 3.- Calculamos el token esperado usando el mismo algoritmo determinista.
+	hasher := sha1.New()
+	hasher.Write([]byte("user@example.com:s3cr3t"))
+	expected := hex.EncodeToString(hasher.Sum(nil))
+	if resp.Token != expected {
+		t.Fatalf("unexpected token: got %q want %q", resp.Token, expected)
+	}
+
+	// 4.- Confirmamos que la expiración esté dentro del rango previsto.
+	remaining := time.Until(resp.ExpiresAt)
+	if remaining < time.Minute || remaining > 2*time.Minute+time.Second {
+		t.Fatalf("unexpected ttl window: %s", remaining)
+	}
+}
+
+func TestAuthenticateRespectsContextCancellation(t *testing.T) {
+	// 1.- Creamos un contexto cancelado que debe propagarse al servicio.
+	svc := NewAuthService(1, time.Minute)
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	// 2.- Verificamos que el servicio devuelva el error del contexto.
+	if _, err := svc.Authenticate(ctx, "mail", "pwd"); err == nil {
+		t.Fatalf("expected context cancellation error")
+	}
+}

--- a/backend/go/internal/service/catalog_test.go
+++ b/backend/go/internal/service/catalog_test.go
@@ -1,0 +1,33 @@
+package service
+
+import (
+	"context"
+	"testing"
+	"time"
+)
+
+func TestCatalogFetchReturnsIsolatedCopy(t *testing.T) {
+	// 1.- Instanciamos el servicio con un único trabajador para simplificar la prueba.
+	svc := NewCatalogService(1)
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+
+	// 2.- Obtenemos el catálogo y modificamos la copia devuelta.
+	catalog, err := svc.Fetch(ctx)
+	if err != nil {
+		t.Fatalf("Fetch returned error: %v", err)
+	}
+	if len(catalog) == 0 {
+		t.Fatalf("expected catalog entries")
+	}
+	catalog[0].Name = "Alterado"
+
+	// 3.- Recuperamos nuevamente para garantizar que la fuente se mantiene intacta.
+	second, err := svc.Fetch(ctx)
+	if err != nil {
+		t.Fatalf("Fetch returned error: %v", err)
+	}
+	if second[0].Name == "Alterado" {
+		t.Fatalf("catalog should be isolated copies between calls")
+	}
+}

--- a/backend/go/internal/service/report_test.go
+++ b/backend/go/internal/service/report_test.go
@@ -1,0 +1,61 @@
+package service
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestReportSubmitAndLookupLifecycle(t *testing.T) {
+	// 1.- Configuramos el servicio de reportes con pools dedicados.
+	svc := NewReportService(2, 2)
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	// 2.- Enviamos un reporte mínimo y validamos la respuesta generada.
+	payload := map[string]any{
+		"incidentTypeId": "pothole",
+		"description":    "Bache profundo",
+		"latitude":       19.43,
+		"longitude":      -99.13,
+	}
+	report, err := svc.Submit(ctx, payload)
+	if err != nil {
+		t.Fatalf("Submit returned error: %v", err)
+	}
+	if !strings.HasPrefix(report.ID, "F-") {
+		t.Fatalf("unexpected folio format: %s", report.ID)
+	}
+	if report.Status != "en_revision" {
+		t.Fatalf("unexpected status: %s", report.Status)
+	}
+
+	// 3.- Consultamos el mismo folio y verificamos el historial simulado.
+	status, err := svc.Lookup(ctx, report.ID)
+	if err != nil {
+		t.Fatalf("Lookup returned error: %v", err)
+	}
+	if status.Folio != report.ID {
+		t.Fatalf("status mismatch: %s vs %s", status.Folio, report.ID)
+	}
+	if len(status.History) < 2 {
+		t.Fatalf("expected history entries, got %d", len(status.History))
+	}
+}
+
+func TestLookupReturnsNotFoundForUnknownFolio(t *testing.T) {
+	// 1.- Iniciamos el servicio para consultar un folio inexistente.
+	svc := NewReportService(1, 1)
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+
+	// 2.- Ejecutamos la búsqueda con un identificador falso.
+	status, err := svc.Lookup(ctx, "F-00000")
+	if err != nil {
+		t.Fatalf("Lookup returned error: %v", err)
+	}
+	if status.Status != "no_encontrado" {
+		t.Fatalf("expected not found status, got %s", status.Status)
+	}
+}


### PR DESCRIPTION
## Summary
- replace the chi dependency with a standard-library mux and explicit method guards
- add end-to-end HTTP handler coverage and unit tests for authentication, catalog, and report services

## Testing
- `GOSUMDB=off go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68e5c6a7af8483298600160dbec9b222