### PR TITLE
Align Go backend routes with OpenAPI spec

### DIFF
--- a/backend/go/internal/httpgin/server_test.go
+++ b/backend/go/internal/httpgin/server_test.go
@@ -13,84 +13,171 @@ import (
 	"github.com/gin-gonic/gin"
 )
 
-func TestReportSubmissionFlow(t *testing.T) {
-	// 1.- Configuramos Gin en modo de pruebas para minimizar el ruido.
+// 1.- buildServer centraliza la creación del servidor de pruebas.
+func buildServer(t *testing.T) *Server {
+	t.Helper()
 	gin.SetMode(gin.TestMode)
-	authSvc := service.NewAuthService(1, time.Minute)
+	authSvc := service.NewAuthService(2, time.Minute)
 	catalogSvc := service.NewCatalogService(1)
-	reportSvc := service.NewReportService(1, 1)
+	reportSvc := service.NewReportService(2, 2)
 	srv := New(authSvc, catalogSvc, reportSvc)
-	defer srv.Shutdown(context.Background())
+	t.Cleanup(func() {
+		_ = srv.Shutdown(context.Background())
+	})
+	return srv
+}
 
-	// 2.- Registramos un cliente simulado para capturar el broadcast del hub.
+func TestOpenAPIEndpointsHappyPath(t *testing.T) {
+	// 2.- Iniciamos el servidor y registramos un usuario nuevo.
+	srv := buildServer(t)
+	registerBody := map[string]string{
+		"email":    "citizen@example.com",
+		"password": "ClaveSegura1",
+	}
+	performJSON(t, srv, http.MethodPost, "/api/v1/auth/register", registerBody, http.StatusCreated, nil)
+
+	// 3.- Validamos el login tradicional.
+	var loginResponse service.AuthResponse
+	performJSON(t, srv, http.MethodPost, "/api/v1/auth/login", registerBody, http.StatusOK, &loginResponse)
+	if loginResponse.Token == "" {
+		t.Fatalf("expected non-empty token from login")
+	}
+
+	// 4.- Recuperación de contraseña debe confirmar la cuenta.
+	recoverBody := map[string]string{"email": registerBody["email"]}
+	performJSON(t, srv, http.MethodPost, "/api/v1/auth/recover", recoverBody, http.StatusAccepted, nil)
+
+	// 5.- Autenticación social valida proveedores soportados.
+	performJSON(t, srv, http.MethodPost, "/api/v1/auth/social/google", map[string]string{}, http.StatusOK, nil)
+
+	// 6.- El catálogo debe responder con tipos disponibles.
+	var catalog []service.IncidentType
+	performRequest(t, srv, http.MethodGet, "/api/v1/catalog/incident-types", nil, http.StatusOK, &catalog)
+	if len(catalog) == 0 {
+		t.Fatalf("expected at least one incident type")
+	}
+
+	// 7.- Capturamos el hub para verificar el broadcast posterior.
 	client := srv.realtimeHub.Register(&captureConn{})
-	// 3.- Enviamos un reporte válido contra el engine y verificamos el código 201.
-	payload := map[string]any{
+
+	// 8.- Ingresamos un reporte completo.
+	reportBody := map[string]any{
 		"incidentTypeId": "pothole",
-		"description":    "Alcantarilla sin tapa",
+		"description":    "Bache profundo",
+		"contactEmail":   registerBody["email"],
+		"contactPhone":   "5512345678",
 		"latitude":       19.4,
 		"longitude":      -99.1,
+		"address":        "Centro, CDMX",
 	}
+	var created service.Report
+	performJSON(t, srv, http.MethodPost, "/api/v1/reports", reportBody, http.StatusCreated, &created)
+	if created.ID == "" {
+		t.Fatalf("expected generated report identifier")
+	}
+
+	// 9.- Confirmamos la notificación WebSocket del nuevo reporte.
+	select {
+	case msg := <-client.Messages():
+		var payload map[string]any
+		if err := json.Unmarshal(msg, &payload); err != nil {
+			t.Fatalf("cannot decode broadcast: %v", err)
+		}
+		if payload["type"] != "report.created" {
+			t.Fatalf("unexpected broadcast type: %v", payload["type"])
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatalf("expected websocket broadcast after submission")
+	}
+
+	// 10.- Listamos los reportes administrativos.
+	var list service.PaginatedReports
+	performRequest(t, srv, http.MethodGet, "/api/v1/reports?page=0&pageSize=10", nil, http.StatusOK, &list)
+	if len(list.Items) == 0 {
+		t.Fatalf("expected paginated items in list endpoint")
+	}
+
+	// 11.- Leemos el reporte directo y comprobamos el ID.
+	var fetched service.Report
+	performRequest(t, srv, http.MethodGet, "/api/v1/reports/"+created.ID, nil, http.StatusOK, &fetched)
+	if fetched.ID != created.ID {
+		t.Fatalf("expected fetched report ID %s, got %s", created.ID, fetched.ID)
+	}
+
+	// 12.- Actualizamos el estatus a resuelto.
+	updateBody := map[string]string{"status": "resuelto"}
+	performJSON(t, srv, http.MethodPatch, "/api/v1/reports/"+created.ID, updateBody, http.StatusOK, &fetched)
+	if fetched.Status != "resuelto" {
+		t.Fatalf("expected updated status resuelto, got %s", fetched.Status)
+	}
+
+	// 13.- El dashboard debe reflejar el conteo de resueltos.
+	var metrics service.AdminDashboardMetrics
+	performRequest(t, srv, http.MethodGet, "/api/v1/admin/dashboard/metrics", nil, http.StatusOK, &metrics)
+	if metrics.ResolvedReports == 0 {
+		t.Fatalf("expected resolved reports metric to be positive")
+	}
+
+	// 14.- Consultamos el folio directo para validar seguimiento.
+	var folio service.FolioStatus
+	performRequest(t, srv, http.MethodGet, "/api/v1/folios/"+created.ID, nil, http.StatusOK, &folio)
+	if folio.Folio != created.ID {
+		t.Fatalf("expected folio %s, got %s", created.ID, folio.Folio)
+	}
+
+	// 15.- Eliminamos el reporte y comprobamos la ausencia posterior.
+	performRequest(t, srv, http.MethodDelete, "/api/v1/reports/"+created.ID, nil, http.StatusNoContent, nil)
+	performRequest(t, srv, http.MethodGet, "/api/v1/reports/"+created.ID, nil, http.StatusNotFound, nil)
+}
+
+func TestMethodEnforcementRemainsActive(t *testing.T) {
+	// 16.- Un GET sobre login debe seguir devolviendo 405.
+	srv := buildServer(t)
+	performRequest(t, srv, http.MethodGet, "/api/v1/auth/login", nil, http.StatusMethodNotAllowed, nil)
+}
+
+// 17.- performJSON ayuda a serializar cuerpos y decodificar respuestas.
+func performJSON(t *testing.T, srv *Server, method, path string, payload any, expected int, target any) {
+	t.Helper()
 	body, err := json.Marshal(payload)
 	if err != nil {
 		t.Fatalf("cannot marshal payload: %v", err)
 	}
-	req := httptest.NewRequest(http.MethodPost, "/reports", bytes.NewReader(body))
-	req.Header.Set("Content-Type", "application/json")
+	performWithBody(t, srv, method, path, bytes.NewReader(body), expected, target)
+}
+
+// 18.- performRequest ejecuta solicitudes sin cuerpo auxiliar.
+func performRequest(t *testing.T, srv *Server, method, path string, body *bytes.Reader, expected int, target any) {
+	t.Helper()
+	var reader *bytes.Reader
+	if body != nil {
+		reader = body
+	} else {
+		reader = bytes.NewReader(nil)
+	}
+	performWithBody(t, srv, method, path, reader, expected, target)
+}
+
+// 19.- performWithBody centraliza la ejecución contra el engine Gin.
+func performWithBody(t *testing.T, srv *Server, method, path string, reader *bytes.Reader, expected int, target any) {
+	t.Helper()
+	req := httptest.NewRequest(method, path, reader)
+	if method == http.MethodPost || method == http.MethodPatch {
+		req.Header.Set("Content-Type", "application/json")
+	}
 	rr := httptest.NewRecorder()
 	srv.Engine().ServeHTTP(rr, req)
-	if rr.Code != http.StatusCreated {
-		t.Fatalf("expected status 201, got %d", rr.Code)
+	if rr.Code != expected {
+		t.Fatalf("expected status %d for %s %s, got %d with body %s", expected, method, path, rr.Code, rr.Body.String())
 	}
-	t.Log("report handler responded")
-	var submitted service.Report
-	if err := json.NewDecoder(rr.Body).Decode(&submitted); err != nil {
-		t.Fatalf("cannot decode response: %v", err)
-	}
-	if submitted.ID == "" {
-		t.Fatalf("expected generated folio identifier")
-	}
-
-	t.Log("decoded report, waiting for broadcast")
-
-	// 4.- Aseguramos que el hub transmita el mensaje de creación del reporte.
-	select {
-	case msg := <-client.Messages():
-		var broadcast map[string]any
-		if err := json.Unmarshal(msg, &broadcast); err != nil {
-			t.Fatalf("cannot decode broadcast: %v", err)
+	if target != nil && rr.Body.Len() > 0 {
+		if err := json.Unmarshal(rr.Body.Bytes(), target); err != nil {
+			t.Fatalf("cannot decode response: %v", err)
 		}
-		if broadcast["type"] != "report.created" {
-			t.Fatalf("unexpected broadcast type: %v", broadcast["type"])
-		}
-		t.Log("received broadcast")
-	case <-time.After(2 * time.Second):
-		t.Fatalf("expected broadcast after report submission")
 	}
 }
 
-func TestMethodEnforcement(t *testing.T) {
-	// 1.- Creamos el servidor y emitimos una solicitud con método incorrecto.
-	gin.SetMode(gin.TestMode)
-	authSvc := service.NewAuthService(1, time.Minute)
-	catalogSvc := service.NewCatalogService(1)
-	reportSvc := service.NewReportService(1, 1)
-	srv := New(authSvc, catalogSvc, reportSvc)
-	defer srv.Shutdown(context.Background())
-
-	req := httptest.NewRequest(http.MethodGet, "/auth", nil)
-	rr := httptest.NewRecorder()
-	srv.Engine().ServeHTTP(rr, req)
-
-	if rr.Code != http.StatusMethodNotAllowed {
-		t.Fatalf("expected status 405, got %d", rr.Code)
-	}
-	if body := rr.Body.String(); body != "method not allowed\n" {
-		t.Fatalf("unexpected body: %q", body)
-	}
-}
-
-// 3.- captureConn implementa la interfaz WebSocket mínima para pruebas.
+// 20.- captureConn implementa la interfaz WebSocket mínima para pruebas.
 type captureConn struct{}
 
 func (c *captureConn) SetReadLimit(int64)                        {}

--- a/backend/go/internal/service/auth.go
+++ b/backend/go/internal/service/auth.go
@@ -4,22 +4,32 @@ import (
 	"context"
 	"crypto/sha1"
 	"encoding/hex"
+	"errors"
 	"fmt"
+	"strings"
+	"sync"
 	"time"
 )
 
-// 1.- AuthService administra solicitudes concurrentes de autenticación.
+// 1.- AuthService administra solicitudes concurrentes y persistencia efímera.
 type AuthService struct {
 	jobs     chan authJob
 	workers  int
 	tokenTTL time.Duration
+	users    map[string]string
+	mu       sync.RWMutex
 }
 
 type authJob struct {
 	email    string
 	password string
 	ctx      context.Context
-	result   chan<- AuthResponse
+	result   chan<- authResult
+}
+
+type authResult struct {
+	response AuthResponse
+	err      error
 }
 
 // 2.- AuthResponse modela la respuesta esperada por el cliente Flutter.
@@ -28,12 +38,20 @@ type AuthResponse struct {
 	ExpiresAt time.Time `json:"expiresAt"`
 }
 
-// 3.- NewAuthService configura el pool de trabajadores.
+// 3.- Declaramos errores reutilizables para mapear códigos HTTP.
+var (
+	ErrInvalidCredentials = errors.New("invalid credentials")
+	ErrEmailConflict      = errors.New("email already registered")
+	ErrUnsupportedLogin   = errors.New("unsupported provider")
+)
+
+// 4.- NewAuthService configura el pool de trabajadores y los registros en memoria.
 func NewAuthService(workers int, tokenTTL time.Duration) *AuthService {
 	s := &AuthService{
 		jobs:     make(chan authJob),
 		workers:  workers,
 		tokenTTL: tokenTTL,
+		users:    make(map[string]string),
 	}
 	for i := 0; i < workers; i++ {
 		go s.worker()
@@ -41,9 +59,9 @@ func NewAuthService(workers int, tokenTTL time.Duration) *AuthService {
 	return s
 }
 
-// 4.- Authenticate coloca el trabajo en cola y espera el resultado.
+// 5.- Authenticate coloca el trabajo en cola y espera el resultado.
 func (s *AuthService) Authenticate(ctx context.Context, email, password string) (AuthResponse, error) {
-	resultCh := make(chan AuthResponse, 1)
+	resultCh := make(chan authResult, 1)
 	job := authJob{email: email, password: password, ctx: ctx, result: resultCh}
 	select {
 	case <-ctx.Done():
@@ -54,11 +72,69 @@ func (s *AuthService) Authenticate(ctx context.Context, email, password string) 
 	case <-ctx.Done():
 		return AuthResponse{}, ctx.Err()
 	case res := <-resultCh:
-		return res, nil
+		if res.err != nil {
+			return AuthResponse{}, res.err
+		}
+		return res.response, nil
 	}
 }
 
-// 5.- worker procesa cada autenticación en segundo plano.
+// 6.- Register almacena un nuevo usuario y devuelve un token recién emitido.
+func (s *AuthService) Register(ctx context.Context, email, password string) (AuthResponse, error) {
+	select {
+	case <-ctx.Done():
+		return AuthResponse{}, ctx.Err()
+	default:
+	}
+	normalized := strings.TrimSpace(strings.ToLower(email))
+	if normalized == "" || strings.TrimSpace(password) == "" {
+		return AuthResponse{}, ErrInvalidCredentials
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if _, exists := s.users[normalized]; exists {
+		return AuthResponse{}, ErrEmailConflict
+	}
+	s.users[normalized] = s.hashPassword(password)
+	return s.newToken(normalized), nil
+}
+
+// 7.- Recover valida la existencia de la cuenta para simular el envío de correo.
+func (s *AuthService) Recover(ctx context.Context, email string) error {
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	default:
+	}
+	normalized := strings.TrimSpace(strings.ToLower(email))
+	if normalized == "" {
+		return ErrInvalidCredentials
+	}
+	s.mu.RLock()
+	_, exists := s.users[normalized]
+	s.mu.RUnlock()
+	if !exists {
+		return ErrInvalidCredentials
+	}
+	return nil
+}
+
+// 8.- SocialAuthenticate genera un token virtual para proveedores federados.
+func (s *AuthService) SocialAuthenticate(ctx context.Context, provider string) (AuthResponse, error) {
+	select {
+	case <-ctx.Done():
+		return AuthResponse{}, ctx.Err()
+	default:
+	}
+	switch provider {
+	case "google", "apple", "facebook":
+		return s.newToken(provider), nil
+	default:
+		return AuthResponse{}, ErrUnsupportedLogin
+	}
+}
+
+// 9.- worker procesa cada autenticación en segundo plano.
 func (s *AuthService) worker() {
 	for job := range s.jobs {
 		select {
@@ -66,12 +142,31 @@ func (s *AuthService) worker() {
 			continue
 		default:
 		}
-		hasher := sha1.New()
-		hasher.Write([]byte(fmt.Sprintf("%s:%s", job.email, job.password)))
-		token := hex.EncodeToString(hasher.Sum(nil))
-		job.result <- AuthResponse{
-			Token:     token,
-			ExpiresAt: time.Now().Add(s.tokenTTL),
+		normalized := strings.TrimSpace(strings.ToLower(job.email))
+		s.mu.RLock()
+		stored, exists := s.users[normalized]
+		s.mu.RUnlock()
+		if !exists || stored != s.hashPassword(job.password) {
+			job.result <- authResult{err: ErrInvalidCredentials}
+			continue
 		}
+		job.result <- authResult{response: s.newToken(normalized)}
 	}
+}
+
+// 10.- newToken centraliza la construcción del token y expiración.
+func (s *AuthService) newToken(seed string) AuthResponse {
+	hasher := sha1.New()
+	hasher.Write([]byte(fmt.Sprintf("%s:%d", seed, time.Now().UnixNano())))
+	return AuthResponse{
+		Token:     hex.EncodeToString(hasher.Sum(nil)),
+		ExpiresAt: time.Now().Add(s.tokenTTL),
+	}
+}
+
+// 11.- hashPassword asegura que las contraseñas se guarden homogeneizadas.
+func (s *AuthService) hashPassword(password string) string {
+	hasher := sha1.New()
+	hasher.Write([]byte(password))
+	return hex.EncodeToString(hasher.Sum(nil))
 }

--- a/backend/go/internal/service/report_test.go
+++ b/backend/go/internal/service/report_test.go
@@ -2,6 +2,7 @@ package service
 
 import (
 	"context"
+	"errors"
 	"strings"
 	"testing"
 	"time"
@@ -51,11 +52,7 @@ func TestLookupReturnsNotFoundForUnknownFolio(t *testing.T) {
 	defer cancel()
 
 	// 2.- Ejecutamos la búsqueda con un identificador falso.
-	status, err := svc.Lookup(ctx, "F-00000")
-	if err != nil {
-		t.Fatalf("Lookup returned error: %v", err)
-	}
-	if status.Status != "no_encontrado" {
-		t.Fatalf("expected not found status, got %s", status.Status)
+	if _, err := svc.Lookup(ctx, "F-00000"); !errors.Is(err, ErrReportNotFound) {
+		t.Fatalf("expected ErrReportNotFound, got %v", err)
 	}
 }


### PR DESCRIPTION
## Summary
- align the Gin router with the OpenAPI contract by mounting the `/api/v1` auth, catalog, report, folio, and admin endpoints and returning JSON error payloads
- expand the auth and report services with registration, recovery, social login, pagination, status updates, deletions, and dashboard metrics needed by the new routes
- add an integration test that walks the OpenAPI happy path and update service unit tests for the revised behaviors
