### PR TITLE
Fix social provider enum and add tests

### DIFF
--- a/lib/src/domain/value_objects/social_provider.dart
+++ b/lib/src/domain/value_objects/social_provider.dart
@@ -1,6 +1,4 @@
-import 'package:equatable/equatable.dart';
-
-enum SocialProvider with EquatableMixin {
+enum SocialProvider {
   google('Google'),
   apple('Apple'),
   facebook('Facebook');
@@ -13,7 +11,4 @@ enum SocialProvider with EquatableMixin {
     //1.- Reutilizamos el nombre del enumerado para exponer un identificador estable hacia el backend.
     return name;
   }
-
-  @override
-  List<Object?> get props => [name];
 }

--- a/test/domain/value_objects/social_provider_test.dart
+++ b/test/domain/value_objects/social_provider_test.dart
@@ -1,0 +1,21 @@
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:flutter_citizen_app/src/domain/value_objects/social_provider.dart';
+
+void main() {
+  group('SocialProvider', () {
+    test('should expose enum name as id', () {
+      //1.- Validamos que cada proveedor reutiliza su nombre como identificador estable.
+      for (final provider in SocialProvider.values) {
+        expect(provider.id, provider.name);
+      }
+    });
+
+    test('should keep expected display name mapping', () {
+      //1.- Comprobamos que los nombres visibles se mantienen conforme a la configuración esperada.
+      expect(SocialProvider.google.displayName, 'Google');
+      expect(SocialProvider.apple.displayName, 'Apple');
+      expect(SocialProvider.facebook.displayName, 'Facebook');
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- remove the Equatable mixin from the SocialProvider enum to avoid overriding equality
- keep the id helper and documented intent without relying on Equatable
- add unit tests to cover the SocialProvider id and display names

## Testing
- flutter test *(fails: flutter command not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68e6afbe9a1883299163d163b169e477