### PR TITLE
Clarify SocialProvider enum usage

### DIFF
--- a/lib/src/domain/value_objects/social_provider.dart
+++ b/lib/src/domain/value_objects/social_provider.dart
@@ -1,8 +1,10 @@
+//1.- Enumeramos los proveedores sociales disponibles junto a su nombre visible.
 enum SocialProvider {
   google('Google'),
   apple('Apple'),
   facebook('Facebook');
 
+  //2.- Asociamos un nombre para mostrar reutilizable en la interfaz de usuario.
   const SocialProvider(this.displayName);
 
   final String displayName;

--- a/test/domain/value_objects/social_provider_test.dart
+++ b/test/domain/value_objects/social_provider_test.dart
@@ -11,6 +11,13 @@ void main() {
       }
     });
 
+    test('should rely on native enum identity for equality', () {
+      //1.- Confirmamos que la igualdad nativa del enum funciona sin necesidad de mezclar EquatableMixin.
+      expect(SocialProvider.google == SocialProvider.google, isTrue);
+      //2.- Validamos que dos proveedores distintos no son iguales para evitar falsos positivos.
+      expect(SocialProvider.google == SocialProvider.apple, isFalse);
+    });
+
     test('should keep expected display name mapping', () {
       //1.- Comprobamos que los nombres visibles se mantienen conforme a la configuración esperada.
       expect(SocialProvider.google.displayName, 'Google');


### PR DESCRIPTION
## Summary
- document the SocialProvider enum to emphasize the built-in identity behaviour instead of mixing in Equatable
- cover the enum's native equality semantics with a dedicated unit test

## Testing
- not run (Flutter SDK unavailable in container)

------
https://chatgpt.com/codex/tasks/task_e_68e6b356d0508329b5a2362cb738181d