### PR TITLE
Add separate citizen and admin app entrypoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,17 +1,16 @@
-# citizen_reports_flutter
+# Citizen Reports Flutter
 
-A new Flutter project.
+This repo hosts the Flutter client for the Citizen Reports initiative. Two entrypoints drive independent experiences:
 
-## Getting Started
+- `lib/main_citizen.dart` – the public citizen dashboard that exposes reporting and folio lookups without authentication.
+- `lib/main_admin.dart` – the administrative panel guarded by the Riverpod-powered session controller.
 
-This project is a starting point for a Flutter application.
+## Building Variants
 
-A few resources to get you started if this is your first Flutter project:
+Run `tool/ci/build_variants.sh` to produce Android and iOS binaries for both shells. The script wires the correct targets:
 
-- [Lab: Write your first Flutter app](https://docs.flutter.dev/get-started/codelab)
-- [Cookbook: Useful Flutter samples](https://docs.flutter.dev/cookbook)
+```bash
+./tool/ci/build_variants.sh
+```
 
-For help getting started with Flutter development, view the
-[online documentation](https://docs.flutter.dev/), which offers tutorials,
-samples, guidance on mobile development, and a full API reference.
-q
+Each command accepts additional Flutter arguments that are forwarded to `flutter build` for customization.

--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -30,6 +30,20 @@ android {
         versionName = flutter.versionName
     }
 
+    flavorDimensions.add("app")
+    productFlavors {
+        create("citizen") {
+            dimension = "app"
+            applicationIdSuffix = ".citizen"
+            versionNameSuffix = "-citizen"
+        }
+        create("admin") {
+            dimension = "app"
+            applicationIdSuffix = ".admin"
+            versionNameSuffix = "-admin"
+        }
+    }
+
     buildTypes {
         release {
             // TODO: Add your own signing config for the release build.

--- a/android/app/src/admin/AndroidManifest.xml
+++ b/android/app/src/admin/AndroidManifest.xml
@@ -1,0 +1,10 @@
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools">
+    <application
+        android:label="Citizen Reports Admin"
+        tools:replace="android:label">
+        <meta-data
+            android:name="flutterTarget"
+            android:value="lib/main_admin.dart" />
+    </application>
+</manifest>

--- a/android/app/src/citizen/AndroidManifest.xml
+++ b/android/app/src/citizen/AndroidManifest.xml
@@ -1,0 +1,10 @@
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools">
+    <application
+        android:label="Citizen Reports"
+        tools:replace="android:label">
+        <meta-data
+            android:name="flutterTarget"
+            android:value="lib/main_citizen.dart" />
+    </application>
+</manifest>

--- a/docs/app/README.md
+++ b/docs/app/README.md
@@ -4,17 +4,19 @@
 The app layer wires together dependencies, bootstraps shared services, and exposes the top-level widgets that drive navigation and session state for the Citizen Reports experience.
 
 ## Key Entry Points
-- [`lib/main.dart`](../../lib/main.dart): Initializes Flutter bindings, builds Riverpod overrides, and launches the `CitizenReportsApp` widget tree.
+- [`lib/main.dart`](../../lib/main.dart) / [`lib/main_citizen.dart`](../../lib/main_citizen.dart): Bootstrap the shared providers and launch the public `CitizenApp` shell.
+- [`lib/main_admin.dart`](../../lib/main_admin.dart): Bootstraps dependencies and mounts the secured `AdminApp` experience.
+- [`lib/src/app/app_bootstrap.dart`](../../lib/src/app/app_bootstrap.dart): Centralizes the Flutter binding initialization and ProviderScope wiring reused by each entrypoint.
 - [`lib/src/app/bootstrap.dart`](../../lib/src/app/bootstrap.dart): Creates the in-memory cache, API client, and repository overrides consumed across the app.
 - [`lib/src/app/providers.dart`](../../lib/src/app/providers.dart): Declares the global providers that expose infrastructure and domain use cases.
 - [`lib/src/app/state/session_controller.dart`](../../lib/src/app/state/session_controller.dart): Manages authentication state transitions through a `StateNotifier`.
-- [`lib/src/app/citizen_reports_app.dart`](../../lib/src/app/citizen_reports_app.dart): Selects the proper navigation shell (public, admin, or loading/error screens) based on the current `SessionState`.
+- [`lib/src/app/citizen_app.dart`](../../lib/src/app/citizen_app.dart) / [`lib/src/app/admin_app.dart`](../../lib/src/app/admin_app.dart): Render the public and administrative MaterialApp roots respectively.
 
 ## Major Flows
 ### Application Bootstrap
-1. `main.dart` ensures bindings are initialized, builds the overrides via `buildAppOverrides`, and wraps the root widget in `ProviderScope`.
+1. `main.dart` and its flavor-specific counterparts delegate to `bootstrapApplication` to initialize Flutter bindings and inject overrides.
 2. `buildAppOverrides` assembles the infrastructure stack (cache, API client, repositories) that satisfy the provider contracts.
-3. `CitizenReportsApp` consumes providers to render either the admin or public navigation graphs.
+3. `CitizenApp` renders the public navigation graph directly, while `AdminApp` listens to session updates to gate administrative routes.
 
 ### Session Management
 1. `sessionControllerProvider` constructs `SessionController` with the `AuthenticateUser` use case.
@@ -22,13 +24,14 @@ The app layer wires together dependencies, bootstraps shared services, and expos
 3. `SessionController.signOut` resets the state so navigation routes fall back to the public experience.
 
 ### Navigation Shell Selection
-1. `CitizenReportsApp` listens to `SessionState` updates to switch between `AdminShell`, `_FullScreenLoader`, `_SessionError`, and `PublicShell`.
-2. `PublicShell` hosts a nested navigator for public routes, while admin flows remain scoped to `AdminShell`.
+1. `AdminApp` listens to `SessionState` updates to switch between `AdminShell`, `_FullScreenLoader`, `_SessionError`, and the `AuthScreen` gate.
+2. `CitizenApp` always renders `PublicShell`, while admin flows remain scoped to `AdminShell` once authenticated.
 
 ## Super-Comment Map
 Use the numbered `//1.-`, `//2.-`, … comments in code to trace documented steps:
-- `main.dart`: startup lifecycle (`//1.-` through `//3.-`).
+- `main.dart`, `main_citizen.dart`, `main_admin.dart`: startup lifecycle (`//1.-`).
+- `lib/src/app/app_bootstrap.dart`: shared bootstrap steps (`//1.-`–`//3.-`).
 - `lib/src/app/bootstrap.dart`: dependency assembly (`//1.-`–`//3.-`).
 - `lib/src/app/providers.dart`: provider contracts and use case wiring (`//1.-`).
 - `lib/src/app/state/session_controller.dart`: session transitions (`//1.-`–`//4.-`).
-- `lib/src/app/citizen_reports_app.dart`: navigation switching and UI feedback (`//1.-`).
+- `lib/src/app/citizen_app.dart` / `lib/src/app/admin_app.dart`: navigation selection (`//1.-`–`//3.-`).

--- a/docs/presentation/README.md
+++ b/docs/presentation/README.md
@@ -24,9 +24,9 @@ The presentation layer renders UI for public citizens and administrators. It rel
 2. Results or errors are displayed in-line, allowing users to retry with cleaned state when needed.
 
 ### Session-Aware Navigation
-1. `CitizenReportsApp` swaps between `PublicShell` and `AdminShell` based on `SessionState`.
-2. Within `PublicShell`, a nested navigator drives map, folio, and home routes without affecting the admin stack.
-3. `AdminShell` offers a scaffold with sign-out actions and quick navigation to `AdminDashboardScreen` summaries.
+1. `CitizenApp` siempre renderiza `PublicShell`, manteniendo el flujo ciudadano desacoplado de la autenticación.
+2. `AdminApp` observa `SessionState` para alternar entre `AuthScreen`, loaders, errores y el `AdminShell` seguro.
+3. Dentro de `PublicShell`, un Navigator anidado conduce mapa, folio y home sin afectar el stack administrativo, mientras `AdminShell` ofrece cierre de sesión y accesos rápidos al `AdminDashboardScreen`.
 
 ## Super-Comment Map
 Refer to the following files to align documentation with code annotations:

--- a/docs/testing/README.md
+++ b/docs/testing/README.md
@@ -6,7 +6,8 @@ Testing artifacts verify the most critical business flows—report submission va
 ## Key Entry Points
 - [`test/domain/usecases/submit_report_use_case_test.dart`](../../test/domain/usecases/submit_report_use_case_test.dart): Exercises validation and submission logic of the `SubmitReport` use case.
 - [`test/data/reports_repository_impl_test.dart`](../../test/data/reports_repository_impl_test.dart): Covers caching, API fallback, and offline recovery for `ReportsRepositoryImpl`.
-- [`test/widget_test.dart`](../../test/widget_test.dart): Smoke-tests the home screen actions using fake authentication tokens.
+- [`test/widget_test.dart`](../../test/widget_test.dart): Smoke-tests that the citizen shell renders the key public entry points by default.
+- [`test/app/admin_app_test.dart`](../../test/app/admin_app_test.dart): Verifies that the admin shell enforces authentication before exposing private navigation.
 
 ## Major Flows
 ### Report Validation Guarantees
@@ -18,10 +19,11 @@ Testing artifacts verify the most critical business flows—report submission va
 2. When the API throws, the implementation returns cached data to maintain continuity—mirroring the super-commented fallback steps.
 
 ### Widget Entry Points
-1. The widget smoke test bootstraps the app with a known token so `CitizenReportsApp` renders the admin dashboard.
-2. It validates that key public actions remain discoverable through rendered buttons, preserving user journeys described in presentation docs.
+1. The citizen smoke test pumps `CitizenApp` to ensure the public dashboard exposes primary calls-to-action.
+2. The admin widget tests override the session controller to confirm authentication gating and the post-login dashboard transition.
 
 ## Super-Comment Map
 - `test/data/reports_repository_impl_test.dart`: Highlights cache seeding, remote calls, and fallback assertions (`//1.-`–`//2.-`).
 - `test/domain/usecases/submit_report_use_case_test.dart`: Marks payload verification and fake responses (`//1.-`, `//2.-`).
-- `test/widget_test.dart`: Annotates token setup and widget discovery steps (`//1.-`).
+- `test/widget_test.dart`: Anota la verificación de accesos públicos (`//1.-`).
+- `test/app/admin_app_test.dart`: Documenta la inyección de sesión y las aserciones del panel administrativo (`//1.-`, `//2.-`).

--- a/ios/Flutter/AdminDebug.xcconfig
+++ b/ios/Flutter/AdminDebug.xcconfig
@@ -1,0 +1,2 @@
+#include "Debug.xcconfig"
+FLUTTER_TARGET=lib/main_admin.dart

--- a/ios/Flutter/AdminProfile.xcconfig
+++ b/ios/Flutter/AdminProfile.xcconfig
@@ -1,0 +1,2 @@
+#include "Release.xcconfig"
+FLUTTER_TARGET=lib/main_admin.dart

--- a/ios/Flutter/AdminRelease.xcconfig
+++ b/ios/Flutter/AdminRelease.xcconfig
@@ -1,0 +1,2 @@
+#include "Release.xcconfig"
+FLUTTER_TARGET=lib/main_admin.dart

--- a/ios/Flutter/Debug.xcconfig
+++ b/ios/Flutter/Debug.xcconfig
@@ -1,1 +1,2 @@
 #include "Generated.xcconfig"
+FLUTTER_TARGET=lib/main.dart

--- a/ios/Flutter/Release.xcconfig
+++ b/ios/Flutter/Release.xcconfig
@@ -1,1 +1,2 @@
 #include "Generated.xcconfig"
+FLUTTER_TARGET=lib/main.dart

--- a/ios/Runner.xcodeproj/project.pbxproj
+++ b/ios/Runner.xcodeproj/project.pbxproj
@@ -47,8 +47,11 @@
 		3B3967151E833CAA004F5970 /* AppFrameworkInfo.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; name = AppFrameworkInfo.plist; path = Flutter/AppFrameworkInfo.plist; sourceTree = "<group>"; };
 		74858FAD1ED2DC5600515810 /* Runner-Bridging-Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "Runner-Bridging-Header.h"; sourceTree = "<group>"; };
 		74858FAE1ED2DC5600515810 /* AppDelegate.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
-		7AFA3C8E1D35360C0083082E /* Release.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; name = Release.xcconfig; path = Flutter/Release.xcconfig; sourceTree = "<group>"; };
-		9740EEB21CF90195004384FC /* Debug.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; name = Debug.xcconfig; path = Flutter/Debug.xcconfig; sourceTree = "<group>"; };
+7AFA3C8E1D35360C0083082E /* Release.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; name = Release.xcconfig; path = Flutter/Release.xcconfig; sourceTree = "<group>"; };
+D91F75C3411E4E41902809A2 /* AdminDebug.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; name = AdminDebug.xcconfig; path = Flutter/AdminDebug.xcconfig; sourceTree = "<group>"; };
+A83D75EBE4E5467F8524FF5F /* AdminRelease.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; name = AdminRelease.xcconfig; path = Flutter/AdminRelease.xcconfig; sourceTree = "<group>"; };
+60E0A71F506A4571A1933F6E /* AdminProfile.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; name = AdminProfile.xcconfig; path = Flutter/AdminProfile.xcconfig; sourceTree = "<group>"; };
+9740EEB21CF90195004384FC /* Debug.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; name = Debug.xcconfig; path = Flutter/Debug.xcconfig; sourceTree = "<group>"; };
 		9740EEB31CF90195004384FC /* Generated.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; name = Generated.xcconfig; path = Flutter/Generated.xcconfig; sourceTree = "<group>"; };
 		97C146EE1CF9000F007C117D /* Runner.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Runner.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		97C146FB1CF9000F007C117D /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/Main.storyboard; sourceTree = "<group>"; };
@@ -76,16 +79,19 @@
 			path = RunnerTests;
 			sourceTree = "<group>";
 		};
-		9740EEB11CF90186004384FC /* Flutter */ = {
-			isa = PBXGroup;
-			children = (
-				3B3967151E833CAA004F5970 /* AppFrameworkInfo.plist */,
-				9740EEB21CF90195004384FC /* Debug.xcconfig */,
-				7AFA3C8E1D35360C0083082E /* Release.xcconfig */,
-				9740EEB31CF90195004384FC /* Generated.xcconfig */,
-			);
-			name = Flutter;
-			sourceTree = "<group>";
+9740EEB11CF90186004384FC /* Flutter */ = {
+isa = PBXGroup;
+children = (
+3B3967151E833CAA004F5970 /* AppFrameworkInfo.plist */,
+9740EEB21CF90195004384FC /* Debug.xcconfig */,
+7AFA3C8E1D35360C0083082E /* Release.xcconfig */,
+D91F75C3411E4E41902809A2 /* AdminDebug.xcconfig */,
+A83D75EBE4E5467F8524FF5F /* AdminRelease.xcconfig */,
+60E0A71F506A4571A1933F6E /* AdminProfile.xcconfig */,
+9740EEB31CF90195004384FC /* Generated.xcconfig */,
+);
+name = Flutter;
+sourceTree = "<group>";
 		};
 		97C146E51CF9000F007C117D = {
 			isa = PBXGroup;
@@ -355,10 +361,10 @@
 			};
 			name = Profile;
 		};
-		249021D4217E4FDB00AE95B9 /* Profile */ = {
-			isa = XCBuildConfiguration;
-			baseConfigurationReference = 7AFA3C8E1D35360C0083082E /* Release.xcconfig */;
-			buildSettings = {
+249021D4217E4FDB00AE95B9 /* Profile */ = {
+isa = XCBuildConfiguration;
+baseConfigurationReference = 7AFA3C8E1D35360C0083082E /* Release.xcconfig */;
+buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_MODULES = YES;
 				CURRENT_PROJECT_VERSION = "$(FLUTTER_BUILD_NUMBER)";
@@ -373,9 +379,51 @@
 				SWIFT_OBJC_BRIDGING_HEADER = "Runner/Runner-Bridging-Header.h";
 				SWIFT_VERSION = 5.0;
 				VERSIONING_SYSTEM = "apple-generic";
-			};
-			name = Profile;
-		};
+};
+name = Profile;
+};
+C96A9913763B4A18B956FBDB /* Profile-admin */ = {
+isa = XCBuildConfiguration;
+baseConfigurationReference = 60E0A71F506A4571A1933F6E /* AdminProfile.xcconfig */;
+buildSettings = {
+ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+CLANG_ENABLE_MODULES = YES;
+CURRENT_PROJECT_VERSION = "$(FLUTTER_BUILD_NUMBER)";
+ENABLE_BITCODE = NO;
+INFOPLIST_FILE = Runner/Info.plist;
+LD_RUNPATH_SEARCH_PATHS = (
+"$(inherited)",
+"@executable_path/Frameworks",
+);
+PRODUCT_BUNDLE_IDENTIFIER = com.citizenreports.citizenReportsFlutter.admin;
+PRODUCT_NAME = "$(TARGET_NAME)";
+SWIFT_OBJC_BRIDGING_HEADER = "Runner/Runner-Bridging-Header.h";
+SWIFT_VERSION = 5.0;
+VERSIONING_SYSTEM = "apple-generic";
+};
+name = "Profile-admin";
+};
+E014BE77265B49309C315DF5 /* Profile-admin */ = {
+isa = XCBuildConfiguration;
+baseConfigurationReference = 7AFA3C8E1D35360C0083082E /* Release.xcconfig */;
+buildSettings = {
+ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+CLANG_ENABLE_MODULES = YES;
+CURRENT_PROJECT_VERSION = "$(FLUTTER_BUILD_NUMBER)";
+ENABLE_BITCODE = NO;
+INFOPLIST_FILE = Runner/Info.plist;
+LD_RUNPATH_SEARCH_PATHS = (
+"$(inherited)",
+"@executable_path/Frameworks",
+);
+PRODUCT_BUNDLE_IDENTIFIER = com.citizenreports.citizenReportsFlutter.admin;
+PRODUCT_NAME = "$(TARGET_NAME)";
+SWIFT_OBJC_BRIDGING_HEADER = "Runner/Runner-Bridging-Header.h";
+SWIFT_VERSION = 5.0;
+VERSIONING_SYSTEM = "apple-generic";
+};
+name = "Profile-admin";
+};
 		331C8088294A63A400263BE5 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
@@ -423,11 +471,11 @@
 			};
 			name = Profile;
 		};
-		97C147031CF9000F007C117D /* Debug */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				ALWAYS_SEARCH_USER_PATHS = NO;
-				ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS = YES;
+97C147031CF9000F007C117D /* Debug */ = {
+isa = XCBuildConfiguration;
+buildSettings = {
+ALWAYS_SEARCH_USER_PATHS = NO;
+ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS = YES;
 				CLANG_ANALYZER_NONNULL = YES;
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
 				CLANG_CXX_LIBRARY = "libc++";
@@ -477,13 +525,70 @@
 				ONLY_ACTIVE_ARCH = YES;
 				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = "1,2";
-			};
-			name = Debug;
-		};
-		97C147041CF9000F007C117D /* Release */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				ALWAYS_SEARCH_USER_PATHS = NO;
+};
+name = Debug;
+};
+DF83B84F18A047949EE0F67E /* Debug-admin */ = {
+isa = XCBuildConfiguration;
+buildSettings = {
+ALWAYS_SEARCH_USER_PATHS = NO;
+ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS = YES;
+CLANG_ANALYZER_NONNULL = YES;
+CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
+CLANG_CXX_LIBRARY = "libc++";
+CLANG_ENABLE_MODULES = YES;
+CLANG_ENABLE_OBJC_ARC = YES;
+CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+CLANG_WARN_BOOL_CONVERSION = YES;
+CLANG_WARN_COMMA = YES;
+CLANG_WARN_CONSTANT_CONVERSION = YES;
+CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+CLANG_WARN_EMPTY_BODY = YES;
+CLANG_WARN_ENUM_CONVERSION = YES;
+CLANG_WARN_INFINITE_RECURSION = YES;
+CLANG_WARN_INT_CONVERSION = YES;
+CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+CLANG_WARN_STRICT_PROTOTYPES = YES;
+CLANG_WARN_SUSPICIOUS_MOVE = YES;
+CLANG_WARN_UNREACHABLE_CODE = YES;
+CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+COPY_PHASE_STRIP = NO;
+DEBUG_INFORMATION_FORMAT = dwarf;
+ENABLE_STRICT_OBJC_MSGSEND = YES;
+ENABLE_TESTABILITY = YES;
+ENABLE_USER_SCRIPT_SANDBOXING = NO;
+GCC_C_LANGUAGE_STANDARD = gnu99;
+GCC_DYNAMIC_NO_PIC = NO;
+GCC_NO_COMMON_BLOCKS = YES;
+GCC_OPTIMIZATION_LEVEL = 0;
+GCC_PREPROCESSOR_DEFINITIONS = (
+"DEBUG=1",
+"$(inherited)",
+);
+GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+GCC_WARN_UNDECLARED_SELECTOR = YES;
+GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+GCC_WARN_UNUSED_FUNCTION = YES;
+GCC_WARN_UNUSED_VARIABLE = YES;
+IPHONEOS_DEPLOYMENT_TARGET = 13.0;
+MTL_ENABLE_DEBUG_INFO = YES;
+ONLY_ACTIVE_ARCH = YES;
+SDKROOT = iphoneos;
+TARGETED_DEVICE_FAMILY = "1,2";
+};
+name = "Debug-admin";
+};
+97C147041CF9000F007C117D /* Release */ = {
+isa = XCBuildConfiguration;
+buildSettings = {
+ALWAYS_SEARCH_USER_PATHS = NO;
 				ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS = YES;
 				CLANG_ANALYZER_NONNULL = YES;
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
@@ -531,13 +636,67 @@
 				SWIFT_OPTIMIZATION_LEVEL = "-O";
 				TARGETED_DEVICE_FAMILY = "1,2";
 				VALIDATE_PRODUCT = YES;
-			};
-			name = Release;
-		};
-		97C147061CF9000F007C117D /* Debug */ = {
-			isa = XCBuildConfiguration;
-			baseConfigurationReference = 9740EEB21CF90195004384FC /* Debug.xcconfig */;
-			buildSettings = {
+};
+name = Release;
+};
+D3A9D993A5024C07BFF94CE5 /* Release-admin */ = {
+isa = XCBuildConfiguration;
+buildSettings = {
+ALWAYS_SEARCH_USER_PATHS = NO;
+ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS = YES;
+CLANG_ANALYZER_NONNULL = YES;
+CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
+CLANG_CXX_LIBRARY = "libc++";
+CLANG_ENABLE_MODULES = YES;
+CLANG_ENABLE_OBJC_ARC = YES;
+CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+CLANG_WARN_BOOL_CONVERSION = YES;
+CLANG_WARN_COMMA = YES;
+CLANG_WARN_CONSTANT_CONVERSION = YES;
+CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+CLANG_WARN_EMPTY_BODY = YES;
+CLANG_WARN_ENUM_CONVERSION = YES;
+CLANG_WARN_INFINITE_RECURSION = YES;
+CLANG_WARN_INT_CONVERSION = YES;
+CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+CLANG_WARN_STRICT_PROTOTYPES = YES;
+CLANG_WARN_SUSPICIOUS_MOVE = YES;
+CLANG_WARN_UNREACHABLE_CODE = YES;
+CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+COPY_PHASE_STRIP = NO;
+DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+ENABLE_NS_ASSERTIONS = NO;
+ENABLE_STRICT_OBJC_MSGSEND = YES;
+ENABLE_USER_SCRIPT_SANDBOXING = NO;
+GCC_C_LANGUAGE_STANDARD = gnu99;
+GCC_NO_COMMON_BLOCKS = YES;
+GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+GCC_WARN_UNDECLARED_SELECTOR = YES;
+GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+GCC_WARN_UNUSED_FUNCTION = YES;
+GCC_WARN_UNUSED_VARIABLE = YES;
+IPHONEOS_DEPLOYMENT_TARGET = 13.0;
+MTL_ENABLE_DEBUG_INFO = NO;
+SDKROOT = iphoneos;
+SUPPORTED_PLATFORMS = iphoneos;
+SWIFT_COMPILATION_MODE = wholemodule;
+SWIFT_OPTIMIZATION_LEVEL = "-O";
+TARGETED_DEVICE_FAMILY = "1,2";
+VALIDATE_PRODUCT = YES;
+};
+name = "Release-admin";
+};
+97C147061CF9000F007C117D /* Debug */ = {
+isa = XCBuildConfiguration;
+baseConfigurationReference = 9740EEB21CF90195004384FC /* Debug.xcconfig */;
+buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_MODULES = YES;
 				CURRENT_PROJECT_VERSION = "$(FLUTTER_BUILD_NUMBER)";
@@ -553,13 +712,35 @@
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				SWIFT_VERSION = 5.0;
 				VERSIONING_SYSTEM = "apple-generic";
-			};
-			name = Debug;
-		};
-		97C147071CF9000F007C117D /* Release */ = {
-			isa = XCBuildConfiguration;
-			baseConfigurationReference = 7AFA3C8E1D35360C0083082E /* Release.xcconfig */;
-			buildSettings = {
+};
+name = Debug;
+};
+AD2D3EADD20A4693BB9B3E9F /* Debug-admin */ = {
+isa = XCBuildConfiguration;
+baseConfigurationReference = D91F75C3411E4E41902809A2 /* AdminDebug.xcconfig */;
+buildSettings = {
+ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+CLANG_ENABLE_MODULES = YES;
+CURRENT_PROJECT_VERSION = "$(FLUTTER_BUILD_NUMBER)";
+ENABLE_BITCODE = NO;
+INFOPLIST_FILE = Runner/Info.plist;
+LD_RUNPATH_SEARCH_PATHS = (
+"$(inherited)",
+"@executable_path/Frameworks",
+);
+PRODUCT_BUNDLE_IDENTIFIER = com.citizenreports.citizenReportsFlutter.admin;
+PRODUCT_NAME = "$(TARGET_NAME)";
+SWIFT_OBJC_BRIDGING_HEADER = "Runner/Runner-Bridging-Header.h";
+SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+SWIFT_VERSION = 5.0;
+VERSIONING_SYSTEM = "apple-generic";
+};
+name = "Debug-admin";
+};
+97C147071CF9000F007C117D /* Release */ = {
+isa = XCBuildConfiguration;
+baseConfigurationReference = 7AFA3C8E1D35360C0083082E /* Release.xcconfig */;
+buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_MODULES = YES;
 				CURRENT_PROJECT_VERSION = "$(FLUTTER_BUILD_NUMBER)";
@@ -574,9 +755,30 @@
 				SWIFT_OBJC_BRIDGING_HEADER = "Runner/Runner-Bridging-Header.h";
 				SWIFT_VERSION = 5.0;
 				VERSIONING_SYSTEM = "apple-generic";
-			};
-			name = Release;
-		};
+};
+name = Release;
+};
+0D8EB8513C79450AABEE9A7E /* Release-admin */ = {
+isa = XCBuildConfiguration;
+baseConfigurationReference = A83D75EBE4E5467F8524FF5F /* AdminRelease.xcconfig */;
+buildSettings = {
+ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+CLANG_ENABLE_MODULES = YES;
+CURRENT_PROJECT_VERSION = "$(FLUTTER_BUILD_NUMBER)";
+ENABLE_BITCODE = NO;
+INFOPLIST_FILE = Runner/Info.plist;
+LD_RUNPATH_SEARCH_PATHS = (
+"$(inherited)",
+"@executable_path/Frameworks",
+);
+PRODUCT_BUNDLE_IDENTIFIER = com.citizenreports.citizenReportsFlutter.admin;
+PRODUCT_NAME = "$(TARGET_NAME)";
+SWIFT_OBJC_BRIDGING_HEADER = "Runner/Runner-Bridging-Header.h";
+SWIFT_VERSION = 5.0;
+VERSIONING_SYSTEM = "apple-generic";
+};
+name = "Release-admin";
+};
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
@@ -590,26 +792,32 @@
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
 		};
-		97C146E91CF9000F007C117D /* Build configuration list for PBXProject "Runner" */ = {
-			isa = XCConfigurationList;
-			buildConfigurations = (
-				97C147031CF9000F007C117D /* Debug */,
-				97C147041CF9000F007C117D /* Release */,
-				249021D3217E4FDB00AE95B9 /* Profile */,
-			);
-			defaultConfigurationIsVisible = 0;
-			defaultConfigurationName = Release;
-		};
-		97C147051CF9000F007C117D /* Build configuration list for PBXNativeTarget "Runner" */ = {
-			isa = XCConfigurationList;
-			buildConfigurations = (
-				97C147061CF9000F007C117D /* Debug */,
-				97C147071CF9000F007C117D /* Release */,
-				249021D4217E4FDB00AE95B9 /* Profile */,
-			);
-			defaultConfigurationIsVisible = 0;
-			defaultConfigurationName = Release;
-		};
+97C146E91CF9000F007C117D /* Build configuration list for PBXProject "Runner" */ = {
+isa = XCConfigurationList;
+buildConfigurations = (
+97C147031CF9000F007C117D /* Debug */,
+DF83B84F18A047949EE0F67E /* Debug-admin */,
+97C147041CF9000F007C117D /* Release */,
+D3A9D993A5024C07BFF94CE5 /* Release-admin */,
+249021D3217E4FDB00AE95B9 /* Profile */,
+E014BE77265B49309C315DF5 /* Profile-admin */,
+);
+defaultConfigurationIsVisible = 0;
+defaultConfigurationName = Release;
+};
+97C147051CF9000F007C117D /* Build configuration list for PBXNativeTarget "Runner" */ = {
+isa = XCConfigurationList;
+buildConfigurations = (
+97C147061CF9000F007C117D /* Debug */,
+AD2D3EADD20A4693BB9B3E9F /* Debug-admin */,
+97C147071CF9000F007C117D /* Release */,
+0D8EB8513C79450AABEE9A7E /* Release-admin */,
+249021D4217E4FDB00AE95B9 /* Profile */,
+C96A9913763B4A18B956FBDB /* Profile-admin */,
+);
+defaultConfigurationIsVisible = 0;
+defaultConfigurationName = Release;
+};
 /* End XCConfigurationList section */
 	};
 	rootObject = 97C146E61CF9000F007C117D /* Project object */;

--- a/ios/Runner.xcodeproj/xcshareddata/xcschemes/admin.xcscheme
+++ b/ios/Runner.xcodeproj/xcshareddata/xcschemes/admin.xcscheme
@@ -1,0 +1,101 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1510"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "97C146ED1CF9000F007C117D"
+               BuildableName = "Runner.app"
+               BlueprintName = "Runner"
+               ReferencedContainer = "container:Runner.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug-admin"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      customLLDBInitFile = "$(SRCROOT)/Flutter/ephemeral/flutter_lldbinit"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "97C146ED1CF9000F007C117D"
+            BuildableName = "Runner.app"
+            BlueprintName = "Runner"
+            ReferencedContainer = "container:Runner.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+      <Testables>
+         <TestableReference
+            skipped = "NO"
+            parallelizable = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "331C8080294A63A400263BE5"
+               BuildableName = "RunnerTests.xctest"
+               BlueprintName = "RunnerTests"
+               ReferencedContainer = "container:Runner.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug-admin"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      customLLDBInitFile = "$(SRCROOT)/Flutter/ephemeral/flutter_lldbinit"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      enableGPUValidationMode = "1"
+      allowLocationSimulation = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "97C146ED1CF9000F007C117D"
+            BuildableName = "Runner.app"
+            BlueprintName = "Runner"
+            ReferencedContainer = "container:Runner.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Profile-admin"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "97C146ED1CF9000F007C117D"
+            BuildableName = "Runner.app"
+            BlueprintName = "Runner"
+            ReferencedContainer = "container:Runner.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug-admin">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release-admin"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/ios/Runner.xcodeproj/xcshareddata/xcschemes/citizen.xcscheme
+++ b/ios/Runner.xcodeproj/xcshareddata/xcschemes/citizen.xcscheme
@@ -1,0 +1,101 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1510"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "97C146ED1CF9000F007C117D"
+               BuildableName = "Runner.app"
+               BlueprintName = "Runner"
+               ReferencedContainer = "container:Runner.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      customLLDBInitFile = "$(SRCROOT)/Flutter/ephemeral/flutter_lldbinit"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "97C146ED1CF9000F007C117D"
+            BuildableName = "Runner.app"
+            BlueprintName = "Runner"
+            ReferencedContainer = "container:Runner.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+      <Testables>
+         <TestableReference
+            skipped = "NO"
+            parallelizable = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "331C8080294A63A400263BE5"
+               BuildableName = "RunnerTests.xctest"
+               BlueprintName = "RunnerTests"
+               ReferencedContainer = "container:Runner.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      customLLDBInitFile = "$(SRCROOT)/Flutter/ephemeral/flutter_lldbinit"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      enableGPUValidationMode = "1"
+      allowLocationSimulation = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "97C146ED1CF9000F007C117D"
+            BuildableName = "Runner.app"
+            BlueprintName = "Runner"
+            ReferencedContainer = "container:Runner.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Profile"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "97C146ED1CF9000F007C117D"
+            BuildableName = "Runner.app"
+            BlueprintName = "Runner"
+            ReferencedContainer = "container:Runner.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/lib/main_admin.dart
+++ b/lib/main_admin.dart
@@ -1,0 +1,7 @@
+import 'src/app/admin_app.dart';
+import 'src/app/app_bootstrap.dart';
+
+Future<void> main() async {
+  //1.- Inicializamos las dependencias compartidas y montamos la experiencia administrativa protegida.
+  await bootstrapApplication(const AdminApp());
+}

--- a/lib/main_citizen.dart
+++ b/lib/main_citizen.dart
@@ -2,6 +2,6 @@ import 'src/app/app_bootstrap.dart';
 import 'src/app/citizen_app.dart';
 
 Future<void> main() async {
-  //1.- Delegamos la inicialización común para compartir configuración entre las variantes.
+  //1.- Inicializamos la infraestructura compartida y lanzamos la experiencia pública.
   await bootstrapApplication(const CitizenApp());
 }

--- a/lib/src/app/admin_app.dart
+++ b/lib/src/app/admin_app.dart
@@ -3,20 +3,21 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../presentation/admin/admin_shell.dart';
 import '../presentation/design/shadcn/shadcn_theme.dart';
-import '../presentation/public/public_shell.dart';
-import 'providers.dart';
+import '../presentation/public/auth/auth_screen.dart';
 import 'state/session_controller.dart';
 
-class CitizenReportsApp extends ConsumerWidget {
-  const CitizenReportsApp({super.key});
+class AdminApp extends ConsumerWidget {
+  const AdminApp({super.key});
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    //1.- Observamos el estado de sesión para decidir qué grafo de navegación mostrar.
+    //1.- Escuchamos la sesión global para decidir si debemos pedir credenciales o mostrar el panel administrativo.
     final session = ref.watch(sessionControllerProvider);
+    //2.- Reutilizamos el mismo tema visual para mantener consistencia entre las experiencias.
     final theme = ShadcnTheme.build();
+    //3.- Construimos un MaterialApp que intercambia su pantalla inicial según el estado de sesión observado.
     return MaterialApp(
-      title: 'Citizen Reports',
+      title: 'Citizen Reports Admin',
       theme: theme,
       home: AnimatedSwitcher(
         duration: const Duration(milliseconds: 250),
@@ -24,7 +25,7 @@ class CitizenReportsApp extends ConsumerWidget {
           SessionStatus.authenticated => const AdminShell(),
           SessionStatus.initializing => const _FullScreenLoader(),
           SessionStatus.error => _SessionError(error: session.errorMessage ?? 'Error de sesión'),
-          _ => const PublicShell(),
+          SessionStatus.signedOut => const AuthScreen(),
         },
       ),
     );
@@ -36,7 +37,7 @@ class _FullScreenLoader extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    //1.- Mostramos un loader simple mientras se ejecutan procesos de autenticación.
+    //1.- Mostramos un indicador de carga de pantalla completa mientras se procesan las credenciales del usuario.
     return const Scaffold(
       body: Center(child: CircularProgressIndicator()),
     );
@@ -50,7 +51,7 @@ class _SessionError extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    //1.- Exponemos el error y permitimos reintentar un inicio de sesión limpio.
+    //1.- Renderizamos el mensaje de error y permitimos limpiar la sesión para reintentar el flujo.
     return Scaffold(
       body: Center(
         child: Padding(

--- a/lib/src/app/app_bootstrap.dart
+++ b/lib/src/app/app_bootstrap.dart
@@ -1,0 +1,18 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import 'bootstrap.dart';
+
+Future<void> bootstrapApplication(Widget root) async {
+  //1.- Garantizamos la inicialización temprana del engine para habilitar canales nativos.
+  WidgetsFlutterBinding.ensureInitialized();
+  //2.- Construimos las dependencias compartidas que serán inyectadas mediante Riverpod.
+  final overrides = await buildAppOverrides();
+  //3.- Ejecutamos la aplicación envolviéndola en un ProviderScope que aplica los overrides configurados.
+  runApp(
+    ProviderScope(
+      overrides: overrides,
+      child: root,
+    ),
+  );
+}

--- a/lib/src/app/citizen_app.dart
+++ b/lib/src/app/citizen_app.dart
@@ -1,0 +1,20 @@
+import 'package:flutter/material.dart';
+
+import '../presentation/design/shadcn/shadcn_theme.dart';
+import '../presentation/public/public_shell.dart';
+
+class CitizenApp extends StatelessWidget {
+  const CitizenApp({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    //1.- Construimos el tema visual compartido utilizando la implementación basada en shadcn/ui.
+    final theme = ShadcnTheme.build();
+    //2.- Exponemos un MaterialApp simplificado que inicia directamente en la navegación pública.
+    return MaterialApp(
+      title: 'Citizen Reports',
+      theme: theme,
+      home: const PublicShell(),
+    );
+  }
+}

--- a/test/app/admin_app_test.dart
+++ b/test/app/admin_app_test.dart
@@ -1,0 +1,66 @@
+import 'package:citizen_reports_flutter/src/app/admin_app.dart';
+import 'package:citizen_reports_flutter/src/app/providers.dart';
+import 'package:citizen_reports_flutter/src/app/state/session_controller.dart';
+import 'package:citizen_reports_flutter/src/domain/entities/auth_credentials.dart';
+import 'package:citizen_reports_flutter/src/domain/repositories/auth_repository.dart';
+import 'package:citizen_reports_flutter/src/domain/usecases/authenticate_user.dart';
+import 'package:citizen_reports_flutter/src/domain/value_objects/auth_token.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+class _FakeAuthRepository implements AuthRepository {
+  @override
+  Future<AuthToken> authenticate(AuthCredentials credentials) async {
+    //1.- Entregamos un token prefabricado para simular respuestas exitosas del backend.
+    return AuthToken('token', expiresAt: DateTime(2030));
+  }
+}
+
+SessionController _buildSessionController({required bool authenticated}) {
+  //1.- Creamos el controlador usando el caso de uso real pero respaldado por el repositorio falso.
+  final controller = SessionController(
+    authenticateUser: AuthenticateUser(authRepository: _FakeAuthRepository()),
+  );
+  if (authenticated) {
+    //2.- Publicamos un token anticipadamente para iniciar la app en modo autenticado.
+    controller.markAuthenticated(AuthToken('token', expiresAt: DateTime(2030)));
+  }
+  return controller;
+}
+
+void main() {
+  testWidgets('AdminApp exige autenticación antes de mostrar rutas privadas', (tester) async {
+    //1.- Montamos la aplicación con la sesión firmada fuera para observar la pantalla de acceso.
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [
+          authRepositoryProvider.overrideWithValue(_FakeAuthRepository()),
+          sessionControllerProvider.overrideWith((ref) => _buildSessionController(authenticated: false)),
+        ],
+        child: const AdminApp(),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    //2.- Confirmamos que se muestra la interfaz de autenticación y no el panel administrativo.
+    expect(find.text('Acceso administrativo'), findsOneWidget);
+    expect(find.text('Panel administrativo'), findsNothing);
+  });
+
+  testWidgets('AdminApp muestra el shell administrativo cuando la sesión está autenticada', (tester) async {
+    //1.- Inyectamos un controlador que ya marcó la sesión como autenticada para saltar la pantalla de login.
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [
+          authRepositoryProvider.overrideWithValue(_FakeAuthRepository()),
+          sessionControllerProvider.overrideWith((ref) => _buildSessionController(authenticated: true)),
+        ],
+        child: const AdminApp(),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    //2.- Verificamos que el panel administrativo sea visible inmediatamente.
+    expect(find.text('Panel administrativo'), findsOneWidget);
+  });
+}

--- a/test/widget_test.dart
+++ b/test/widget_test.dart
@@ -1,32 +1,12 @@
-import 'package:citizen_reports_flutter/src/app/citizen_reports_app.dart';
-import 'package:citizen_reports_flutter/src/app/providers.dart';
-import 'package:citizen_reports_flutter/src/domain/entities/auth_credentials.dart';
-import 'package:citizen_reports_flutter/src/domain/repositories/auth_repository.dart';
-import 'package:citizen_reports_flutter/src/domain/value_objects/auth_token.dart';
+import 'package:citizen_reports_flutter/src/app/citizen_app.dart';
 import 'package:flutter_test/flutter_test.dart';
-import 'package:flutter_riverpod/flutter_riverpod.dart';
-
-class _FakeAuthRepository implements AuthRepository {
-  @override
-  Future<AuthToken> authenticate(AuthCredentials credentials) async {
-    //1.- Generamos un token fijo para simular autenticaciones exitosas.
-    return AuthToken('token', expiresAt: DateTime.now().add(const Duration(hours: 1)));
-  }
-}
 
 void main() {
-  testWidgets('muestra acciones principales en la pantalla ciudadana', (tester) async {
-    await tester.pumpWidget(
-      ProviderScope(
-        overrides: [
-          authRepositoryProvider.overrideWithValue(_FakeAuthRepository()),
-        ],
-        child: const CitizenReportsApp(),
-      ),
-    );
+  testWidgets('CitizenApp arranca mostrando accesos ciudadanos clave', (tester) async {
+    await tester.pumpWidget(const CitizenApp());
 
-    //1.- Buscamos los botones principales que replican la pantalla web.
-    expect(find.text('Reportar incidencia'), findsOneWidget);
-    expect(find.text('Consultar folio'), findsOneWidget);
+    //1.- Verificamos que la experiencia predeterminada expone las llamadas a la acción públicas.
+    expect(find.text('Comenzar reporte'), findsOneWidget);
+    expect(find.text('Consultar'), findsOneWidget);
   });
 }

--- a/tool/ci/build_variants.sh
+++ b/tool/ci/build_variants.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+#1.- Construimos la variante ciudadana apuntando al nuevo entrypoint sin autenticación.
+flutter build apk --flavor citizen -t lib/main_citizen.dart "$@"
+#2.- Construimos la variante administrativa que exige sesión autenticada.
+flutter build apk --flavor admin -t lib/main_admin.dart "$@"
+#3.- Generamos los artefactos de iOS sin firmar para ambas experiencias.
+flutter build ios --flavor citizen --no-codesign -t lib/main_citizen.dart "$@"
+#4.- Repetimos el build de iOS para la variante administrativa utilizando el entrypoint protegido.
+flutter build ios --flavor admin --no-codesign -t lib/main_admin.dart "$@"


### PR DESCRIPTION
## Summary
- add citizen and admin specific main entrypoints powered by a shared bootstrap helper
- split the MaterialApp roots so the public shell no longer depends on authentication while the admin shell gates on session state
- configure Android flavors, iOS schemes, and a CI helper script to target the correct Dart entrypoint for each build
- update documentation and widget tests to cover the new citizen and admin flows

## Testing
- `flutter test` *(fails: Flutter SDK not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68e6d14e047c8329882daf65d4be04c6